### PR TITLE
Fix nightly model push race

### DIFF
--- a/.github/workflows/nightly-self-play.yml
+++ b/.github/workflows/nightly-self-play.yml
@@ -5,6 +5,10 @@ on:
     - cron: "47 9 * * *"
   workflow_dispatch: {}
 
+concurrency:
+  group: model-training-master
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -39,5 +43,9 @@ jobs:
             echo "No model changes to commit"
             exit 0
           fi
+          git stash push --staged --include-untracked -m nightly-self-training-update
+          git pull --rebase origin master
+          git stash pop
+          git add public/nn ml/checkpoints ml/data/self_play_buffer.json ml/training_history.json
           git commit -m "Nightly: continue self training"
           git push

--- a/.github/workflows/nightly-train.yml
+++ b/.github/workflows/nightly-train.yml
@@ -7,6 +7,10 @@ on:
     - cron: "17 9 * * *"
   workflow_dispatch: {}
 
+concurrency:
+  group: model-training-master
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -47,5 +51,9 @@ jobs:
             echo "No model changes to commit"
             exit 0
           fi
+          git stash push --staged --include-untracked -m nightly-model-update
+          git pull --rebase origin master
+          git stash pop
+          git add public/nn ml/checkpoints ml/data/replay_buffer.json ml/training_history.json
           git commit -m "Nightly: continue NN learning"
           git push


### PR DESCRIPTION
## Summary

- Add a shared concurrency group to the two model-training workflows
- Stash generated model files before syncing with `origin/master`
- Pull/rebase onto the latest `master`, reapply generated files, then commit and push

## Why

The training job succeeded and created the updated model artifacts, but the final push was rejected because `master` had moved while the workflow was running. These changes make the workflow sync right before committing generated artifacts and prevent the two training workflows from racing each other.

## Testing

Not run locally in this environment