### PR TITLE
Clean generated leftovers before nightly rebase

### DIFF
--- a/.github/workflows/nightly-self-play.yml
+++ b/.github/workflows/nightly-self-play.yml
@@ -44,5 +44,7 @@ jobs:
             exit 0
           fi
           git commit -m "Nightly: continue self training"
+          git reset --hard HEAD
+          git clean -fd
           git pull --rebase origin master
           git push

--- a/.github/workflows/nightly-train.yml
+++ b/.github/workflows/nightly-train.yml
@@ -52,5 +52,7 @@ jobs:
             exit 0
           fi
           git commit -m "Nightly: continue NN learning"
+          git reset --hard HEAD
+          git clean -fd
           git pull --rebase origin master
           git push


### PR DESCRIPTION
## Summary

- Keep committing the intended model artifacts first
- Reset and clean leftover generated/intermediate files before pulling with rebase
- Apply the same cleanup to both nightly model workflows

## Why

The workflow successfully created the generated model commit, but `git pull --rebase` failed because intermediate files were still dirty in the working tree. Cleaning after the intended artifact commit lets the rebase run without discarding the committed model update.

## Testing

Not run locally in this environment