### PR TITLE
Quiet TensorFlow training startup noise

### DIFF
--- a/.github/workflows/nightly-train.yml
+++ b/.github/workflows/nightly-train.yml
@@ -41,7 +41,14 @@ jobs:
       - name: Evaluate with Stockfish
         run: SF_DEPTH=12 STOCKFISH_PATH=stockfish python ml/stockfish_eval.py
       - name: Continue NN learning + export TFJS
-        run: python ml/train_safe_export.py
+        run: |
+          set -o pipefail
+          python ml/train_safe_export.py 2>&1 | sed \
+            -e '/ydf\.readthedocs\.io/d' \
+            -e '/successor of TensorFlow Decision Forests/d' \
+            -e '/failed to lookup keras version from the file/d' \
+            -e '/this is likely a weight only file/d' \
+            -e '/HDF5 file format is considered legacy/d'
       - name: Commit updated brain and browser model
         run: |
           git config user.name "github-actions[bot]"

--- a/ml/train_safe_export.py
+++ b/ml/train_safe_export.py
@@ -2,6 +2,18 @@
 """
 run training with a guarded TensorFlow.js export import
 """
+import logging
+import os
+import warnings
+
+# GitHub's CPU runners can expose partial CUDA libraries. Force CPU-only TensorFlow
+# before importing train.py so cuFFT/cuDNN/cuBLAS/cuInit noise is avoided.
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+os.environ.setdefault("ABSL_LOG_LEVEL", "3")
+
+warnings.filterwarnings("ignore", message=".*HDF5 file format is considered legacy.*")
+logging.getLogger("absl").setLevel(logging.ERROR)
 
 try:
     from google.protobuf import runtime_version


### PR DESCRIPTION
## Summary

- Force CPU-only TensorFlow startup in `ml/train_safe_export.py` before importing training code
- Raise TensorFlow/absl log thresholds and ignore the known Keras legacy-save warning
- Keep the actual training and model-gate logic unchanged

## Testing

Not run locally in this environment.