### PR TITLE
Batch neural search and scale training data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write   # required to push to gh-pages
 
+concurrency:
+  group: chess-pages
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -20,7 +24,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/nightly-self-play.yml
+++ b/.github/workflows/nightly-self-play.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   train:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
@@ -31,15 +31,19 @@ jobs:
         run: python -m unittest discover -s ml/tests -p "test_*.py"
       - name: Generate neural MCTS self-play games
         env:
-          AZ_SELF_PLAY_GAMES: "4"
-          AZ_MCTS_SEARCHES: "80"
+          AZ_SELF_PLAY_GAMES: "16"
+          AZ_SELF_PLAY_BATCH_SIZE: "8"
+          AZ_MCTS_SEARCHES: "96"
+          AZ_MAX_SELF_PLAY_SAMPLES: "20000"
           AZ_SELF_PLAY_SEED: ${{ github.run_number }}
         run: python ml/self_play.py
       - name: Continue policy-value learning, evaluate, and export model
         env:
           TRAIN_SEED: ${{ github.run_number }}
-          AZ_ARENA_GAMES: "2"
-          AZ_ARENA_SEARCHES: "24"
+          AZ_MAX_SELF_PLAY_TRAIN: "12000"
+          AZ_MAX_STOCKFISH_TRAIN: "12000"
+          AZ_ARENA_GAMES: "8"
+          AZ_ARENA_SEARCHES: "48"
           AZ_ARENA_MIN_SCORE: "0.5"
         run: python ml/train_safe_export.py
       - name: Commit updated model state

--- a/.github/workflows/nightly-train.yml
+++ b/.github/workflows/nightly-train.yml
@@ -59,8 +59,10 @@ jobs:
       - name: Continue NN learning, evaluate, and export TFJS
         env:
           TRAIN_SEED: ${{ github.run_number }}
-          AZ_ARENA_GAMES: "2"
-          AZ_ARENA_SEARCHES: "24"
+          AZ_MAX_SELF_PLAY_TRAIN: "12000"
+          AZ_MAX_STOCKFISH_TRAIN: "12000"
+          AZ_ARENA_GAMES: "8"
+          AZ_ARENA_SEARCHES: "48"
           AZ_ARENA_MIN_SCORE: "0.5"
         run: python ml/train_safe_export.py
       - name: Commit updated brain and browser model

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Playable at [ritchiek.tech/chess](https://superritchie.github.io/chess/).
 
 - **Random** chooses uniformly from legal moves.
 - **NN** uses a shallow negamax search with the neural value head at leaf positions.
-- **MCTS** is AlphaZero-style neural PUCT: policy priors guide selection and the neural value replaces random rollouts.
+- **Neural MCTS** is AlphaZero-style PUCT with batched leaf evaluation, so the browser explores more positions inside a two-second move budget.
 
 The policy/value network receives 18 feature planes: 12 piece planes, side to move, four castling-right planes, and the en-passant target. Its policy space represents normal moves plus queen, rook, bishop, and knight promotions separately.
 
@@ -15,7 +15,9 @@ The policy/value network receives 18 feature planes: 12 piece planes, side to mo
 Two serialized GitHub Actions workflows share the same model-training concurrency group:
 
 1. **Nightly NN training** downloads recent Lichess games, samples positions, evaluates uncached positions with Stockfish, and trains the value head alongside the existing self-play policy data.
-2. **Nightly policy-value self training** generates games with neural MCTS and trains both the policy and value heads from `(state, MCTS visit distribution, final outcome)` samples.
+2. **Nightly policy-value self training** generates 16 games in parallel batches, retains up to 20,000 replay samples, and trains both heads from `(state, MCTS visit distribution, final outcome)` samples.
+
+Each accepted run can train on up to 12,000 self-play positions and 12,000 Stockfish positions. Batched inference lets the workflow collect substantially more games while keeping the run bounded.
 
 A candidate checkpoint replaces the current model only when:
 
@@ -40,7 +42,11 @@ npm run build
 The workflows provide defaults, and the main controls can also be overridden locally:
 
 - `AZ_SELF_PLAY_GAMES`
+- `AZ_SELF_PLAY_BATCH_SIZE`
 - `AZ_MCTS_SEARCHES`
+- `AZ_MAX_SELF_PLAY_SAMPLES`
+- `AZ_MAX_SELF_PLAY_TRAIN`
+- `AZ_MAX_STOCKFISH_TRAIN`
 - `AZ_SELF_PLAY_SEED`
 - `AZ_ARENA_GAMES`
 - `AZ_ARENA_SEARCHES`

--- a/ml/README.md
+++ b/ml/README.md
@@ -17,9 +17,12 @@ ml/
 1. fetch recent Lichess games
 2. sample board positions
 3. label positions with Stockfish
-4. merge new labels into `ml/data/replay_buffer.json`
-5. load `ml/checkpoints/chess_eval.keras` when it exists
-6. continue training from that saved brain
-7. save the updated checkpoint, browser model, replay buffer, and metrics
+4. generate self-play games concurrently and batch neural leaf evaluation across active games
+5. retain up to 20,000 self-play samples and 50,000 Stockfish labels
+6. train on up to 12,000 positions from each replay source per run
+7. load `ml/checkpoints/chess_eval.keras` when it exists
+8. continue training from that saved brain
+9. compare the candidate over eight paired-color arena games
+10. save the accepted checkpoint, browser model, replay buffer, and metrics
 
 The first run starts from scratch. Later runs continue from the saved checkpoint instead of replacing the model with a brand-new one.

--- a/ml/self_play.py
+++ b/ml/self_play.py
@@ -17,9 +17,10 @@ CHECKPOINT_MODEL = pathlib.Path("ml/checkpoints/chess_eval.keras")
 SELF_PLAY_BUFFER = pathlib.Path("ml/data/self_play_buffer.json")
 
 SELF_PLAY_GAMES = int(os.environ.get("AZ_SELF_PLAY_GAMES", "4"))
+SELF_PLAY_BATCH_SIZE = int(os.environ.get("AZ_SELF_PLAY_BATCH_SIZE", "4"))
 MCTS_SEARCHES = int(os.environ.get("AZ_MCTS_SEARCHES", "80"))
 MAX_PLIES = int(os.environ.get("AZ_MAX_PLIES", "180"))
-MAX_BUFFER = int(os.environ.get("AZ_MAX_SELF_PLAY_SAMPLES", "8000"))
+MAX_BUFFER = int(os.environ.get("AZ_MAX_SELF_PLAY_SAMPLES", "20000"))
 CPUCT = float(os.environ.get("AZ_CPUCT", "1.5"))
 DIRICHLET_ALPHA = float(os.environ.get("AZ_DIRICHLET_ALPHA", "0.3"))
 DIRICHLET_EPSILON = float(os.environ.get("AZ_DIRICHLET_EPSILON", "0.25"))
@@ -94,28 +95,47 @@ def terminal_value(board):
     return 1.0 if outcome.winner == board.turn else -1.0
 
 
-def model_policy_value(model, board):
-    legal_moves = list(board.legal_moves)
-    if not legal_moves:
-        return {}, terminal_value(board) or 0.0
+def model_policy_value_batch(model, boards):
+    if not boards:
+        return []
 
+    legal_moves_by_board = [list(board.legal_moves) for board in boards]
     if model is None:
-        probability = 1.0 / len(legal_moves)
-        return {move_to_index(move): probability for move in legal_moves}, 0.0
+        results = []
+        for board, legal_moves in zip(boards, legal_moves_by_board):
+            if not legal_moves:
+                results.append(({}, terminal_value(board) or 0.0))
+                continue
+            probability = 1.0 / len(legal_moves)
+            results.append(({move_to_index(move): probability for move in legal_moves}, 0.0))
+        return results
 
-    features = board_to_features(board.fen(en_passant="fen")).reshape(1, 8, 8, PLANES).astype(np.float32)
-    prediction = model.predict(features, verbose=0)
+    features = np.stack(
+        [board_to_features(board.fen(en_passant="fen")).reshape(8, 8, PLANES) for board in boards]
+    ).astype(np.float32)
+    prediction = model(features, training=False)
     if not isinstance(prediction, (list, tuple)) or len(prediction) != 2:
-        probability = 1.0 / len(legal_moves)
-        return {move_to_index(move): probability for move in legal_moves}, 0.0
+        return model_policy_value_batch(None, boards)
 
-    policy_logits, value = prediction
-    logits = np.asarray(policy_logits[0], dtype=np.float32)
-    legal_indices = [move_to_index(move) for move in legal_moves]
-    legal_logits = np.array([logits[index] for index in legal_indices], dtype=np.float32)
-    legal_probabilities = softmax(legal_logits)
-    priors = {index: float(probability) for index, probability in zip(legal_indices, legal_probabilities)}
-    return priors, float(value[0][0])
+    policy_logits, values = (np.asarray(output, dtype=np.float32) for output in prediction)
+    results = []
+    for board_index, (board, legal_moves) in enumerate(zip(boards, legal_moves_by_board)):
+        if not legal_moves:
+            results.append(({}, terminal_value(board) or 0.0))
+            continue
+        legal_indices = [move_to_index(move) for move in legal_moves]
+        legal_logits = policy_logits[board_index, legal_indices]
+        legal_probabilities = softmax(legal_logits)
+        priors = {
+            index: float(probability)
+            for index, probability in zip(legal_indices, legal_probabilities)
+        }
+        results.append((priors, float(values[board_index][0])))
+    return results
+
+
+def model_policy_value(model, board):
+    return model_policy_value_batch(model, [board])[0]
 
 
 class Node:
@@ -172,38 +192,67 @@ def add_root_noise(root):
         child.prior = (1 - DIRICHLET_EPSILON) * child.prior + DIRICHLET_EPSILON * float(sample)
 
 
-def run_search(model, board, searches=None, add_noise=True):
+def run_search_batch(model, boards, searches=None, add_noise=True):
+    if not boards:
+        return []
     searches = MCTS_SEARCHES if searches is None else int(searches)
-    root = Node(board.copy(stack=True))
-    priors, root_value = model_policy_value(model, root.board)
-    root.expand(priors)
-    if add_noise:
-        add_root_noise(root)
-    root.visit_count = 1
-    root.value_sum = root_value
+    roots = [Node(board.copy(stack=True)) for board in boards]
+    root_predictions = model_policy_value_batch(model, [root.board for root in roots])
+    for root, (priors, root_value) in zip(roots, root_predictions):
+        root.expand(priors)
+        if add_noise:
+            add_root_noise(root)
+        root.visit_count = 1
+        root.value_sum = root_value
 
     for _ in range(max(1, searches)):
-        node = root
-        while node.children:
-            node = node.select_child()
+        leaves = []
+        values = [None] * len(roots)
+        pending_indices = []
+
+        for root_index, root in enumerate(roots):
+            node = root
+            while node.children:
+                node = node.select_child()
+                if node is None:
+                    break
+            leaves.append(node)
             if node is None:
-                break
-        if node is None:
-            break
+                continue
+            value = terminal_value(node.board)
+            if value is None:
+                pending_indices.append(root_index)
+            else:
+                values[root_index] = value
 
-        value = terminal_value(node.board)
-        if value is None:
-            priors, value = model_policy_value(model, node.board)
+        predictions = model_policy_value_batch(
+            model,
+            [leaves[index].board for index in pending_indices],
+        )
+        for root_index, (priors, value) in zip(pending_indices, predictions):
+            node = leaves[root_index]
             node.expand(priors)
-        node.backup(value)
+            values[root_index] = value
 
-    visits = {index: child.visit_count for index, child in root.children.items()}
-    total = sum(visits.values())
-    if total <= 0:
-        legal_indices = [move_to_index(move) for move in board.legal_moves]
-        probability = 1.0 / max(1, len(legal_indices))
-        return {index: probability for index in legal_indices}
-    return {index: count / total for index, count in visits.items()}
+        for node, value in zip(leaves, values):
+            if node is not None and value is not None:
+                node.backup(value)
+
+    policies = []
+    for root, board in zip(roots, boards):
+        visits = {index: child.visit_count for index, child in root.children.items()}
+        total = sum(visits.values())
+        if total <= 0:
+            legal_indices = [move_to_index(move) for move in board.legal_moves]
+            probability = 1.0 / max(1, len(legal_indices))
+            policies.append({index: probability for index in legal_indices})
+        else:
+            policies.append({index: count / total for index, count in visits.items()})
+    return policies
+
+
+def run_search(model, board, searches=None, add_noise=True):
+    return run_search_batch(model, [board], searches=searches, add_noise=add_noise)[0]
 
 
 def choose_action(policy, move_number, sample=True):
@@ -227,36 +276,55 @@ def result_for_white(board):
     return 1.0 if outcome.winner == chess.WHITE else -1.0
 
 
-def play_game(model, game_index):
-    board = chess.Board()
-    samples = []
-
+def play_games(model, first_game_index, game_count):
+    games = [
+        {"board": chess.Board(), "samples": [], "game_index": first_game_index + offset}
+        for offset in range(game_count)
+    ]
     for ply in range(MAX_PLIES):
-        if board.is_game_over(claim_draw=True):
+        active = [game for game in games if not game["board"].is_game_over(claim_draw=True)]
+        if not active:
             break
-        policy = run_search(model, board, add_noise=True)
-        action = choose_action(policy, ply, sample=True)
-        legal_by_index = {move_to_index(move): move for move in board.legal_moves}
-        move = legal_by_index.get(action)
-        if move is None:
-            move = random.choice(list(board.legal_moves))
+        policies = run_search_batch(model, [game["board"] for game in active], add_noise=True)
+        for game, policy in zip(active, policies):
+            board = game["board"]
+            action = choose_action(policy, ply, sample=True)
+            legal_by_index = {move_to_index(move): move for move in board.legal_moves}
+            move = legal_by_index.get(action)
+            if move is None:
+                move = random.choice(list(board.legal_moves))
 
-        samples.append(
-            {
-                "fen": board.fen(en_passant="fen"),
-                "turn": "white" if board.turn == chess.WHITE else "black",
-                "policy_version": POLICY_VERSION,
-                "policy": [[int(index), float(probability)] for index, probability in policy.items() if probability > 0],
-            }
+            game["samples"].append(
+                {
+                    "fen": board.fen(en_passant="fen"),
+                    "turn": "white" if board.turn == chess.WHITE else "black",
+                    "policy_version": POLICY_VERSION,
+                    "policy": [
+                        [int(index), float(probability)]
+                        for index, probability in policy.items()
+                        if probability > 0
+                    ],
+                }
+            )
+            board.push(move)
+
+    completed_samples = []
+    for game in games:
+        board = game["board"]
+        samples = game["samples"]
+        white_result = result_for_white(board)
+        for sample in samples:
+            sample["z"] = white_result if sample["turn"] == "white" else -white_result
+        print(
+            f"[self-play] game {game['game_index'] + 1}: "
+            f"{len(samples)} plies, result {board.result(claim_draw=True)}"
         )
-        board.push(move)
+        completed_samples.append(samples)
+    return completed_samples
 
-    white_result = result_for_white(board)
-    for sample in samples:
-        sample["z"] = white_result if sample["turn"] == "white" else -white_result
 
-    print(f"[self-play] game {game_index + 1}: {len(samples)} plies, result {board.result(claim_draw=True)}")
-    return samples
+def play_game(model, game_index):
+    return play_games(model, game_index, 1)[0]
 
 
 def play_arena_game(candidate, baseline, candidate_is_white, searches=24, max_plies=160, opening=None):
@@ -287,7 +355,16 @@ def play_arena_game(candidate, baseline, candidate_is_white, searches=24, max_pl
 
 
 def arena_score(candidate, baseline, games=2, searches=24, max_plies=160):
-    openings = (("e2e4", "e7e5"), ("d2d4", "d7d5"), ("c2c4", "e7e5"))
+    openings = (
+        ("e2e4", "e7e5"),
+        ("d2d4", "d7d5"),
+        ("c2c4", "e7e5"),
+        ("g1f3", "d7d5"),
+        ("e2e4", "c7c5"),
+        ("d2d4", "g8f6"),
+        ("c2c4", "c7c5"),
+        ("g1f3", "g8f6"),
+    )
     scores = []
     for game_index in range(max(0, games)):
         candidate_is_white = game_index % 2 == 0
@@ -311,8 +388,11 @@ def main():
     existing = read_json_list(SELF_PLAY_BUFFER)
     new_samples = []
 
-    for game_index in range(SELF_PLAY_GAMES):
-        new_samples.extend(play_game(model, game_index))
+    batch_size = max(1, SELF_PLAY_BATCH_SIZE)
+    for first_game_index in range(0, SELF_PLAY_GAMES, batch_size):
+        game_count = min(batch_size, SELF_PLAY_GAMES - first_game_index)
+        for samples in play_games(model, first_game_index, game_count):
+            new_samples.extend(samples)
 
     merged = existing + new_samples
     if len(merged) > MAX_BUFFER:

--- a/ml/tests/test_alpha_zero_core.py
+++ b/ml/tests/test_alpha_zero_core.py
@@ -76,6 +76,30 @@ class SearchAndModelTests(unittest.TestCase):
             (False, "previous_validation_failed"),
         )
 
+    def test_batched_search_shares_model_calls_across_games(self):
+        class CountingModel:
+            def __init__(self):
+                self.calls = 0
+
+            def __call__(self, features_batch, training=False):
+                self.calls += 1
+                batch_size = len(features_batch)
+                return [
+                    np.zeros((batch_size, policy_map.POLICY_SIZE), dtype=np.float32),
+                    np.zeros((batch_size, 1), dtype=np.float32),
+                ]
+
+        model = CountingModel()
+        boards = [chess.Board(), chess.Board()]
+        policies = self_play.run_search_batch(model, boards, searches=3, add_noise=False)
+
+        self.assertEqual(model.calls, 4)
+        self.assertEqual(len(policies), 2)
+        for board, policy in zip(boards, policies):
+            legal_indices = {policy_map.move_to_index(move) for move in board.legal_moves}
+            self.assertEqual(set(policy), legal_indices)
+            self.assertAlmostEqual(sum(policy.values()), 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ml/train.py
+++ b/ml/train.py
@@ -35,8 +35,8 @@ CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
 BOARD_H, BOARD_W = 8, 8
 FLAT_SIZE = BOARD_H * BOARD_W * PLANES
 MAX_REPLAY_ITEMS = int(os.environ.get("MAX_REPLAY_ITEMS", "50000"))
-MAX_SELF_PLAY_TRAIN = int(os.environ.get("AZ_MAX_SELF_PLAY_TRAIN", "4000"))
-MAX_STOCKFISH_TRAIN = int(os.environ.get("AZ_MAX_STOCKFISH_TRAIN", "8000"))
+MAX_SELF_PLAY_TRAIN = int(os.environ.get("AZ_MAX_SELF_PLAY_TRAIN", "12000"))
+MAX_STOCKFISH_TRAIN = int(os.environ.get("AZ_MAX_STOCKFISH_TRAIN", "12000"))
 COLD_START_EPOCHS = int(os.environ.get("COLD_START_EPOCHS", "6"))
 CONTINUE_EPOCHS = int(os.environ.get("CONTINUE_EPOCHS", "3"))
 COLD_START_LR = float(os.environ.get("COLD_START_LR", "1e-3"))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chess",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://SuperRitchie.github.io/chess",
+  "homepage": "https://SuperRitchie.github.io/chess",
   "dependencies": {
     "@tensorflow/tfjs": "^4.22.0",
     "@testing-library/jest-dom": "^6.0.0",

--- a/src/ChessBoard.js
+++ b/src/ChessBoard.js
@@ -452,9 +452,9 @@ export default function ChessBoard() {
       aiMove = await pickRandomMove(pieces, color, enPassantTarget);
     } else if (mode === "mcts") {
       aiMove = await pickMCTSMove(pieces, color, enPassantTarget, {
-        timeMs: 1200,
-        maxIterations: 3000,
-        rolloutDepth: 40,
+        timeMs: 2000,
+        maxIterations: 4096,
+        batchSize: 16,
       });
     } else if (mode === "nn") {
       aiMove = await pickNNMove(pieces, color, enPassantTarget);
@@ -527,7 +527,7 @@ export default function ChessBoard() {
   const modes = [
     { key: "human", label: "Human" },
     { key: "random", label: "Random" },
-    { key: "mcts", label: "MCTS" },
+    { key: "mcts", label: "Neural MCTS" },
     { key: "nn", label: "NN" },
   ];
 

--- a/src/ai/mctsAI.js
+++ b/src/ai/mctsAI.js
@@ -1,5 +1,9 @@
 import { makeMove, isKingInCheck, listLegalMoves } from '../rules/chessRules';
-import { moveKey, predictPolicyValueForMoves } from './nnAI';
+import {
+  moveKey,
+  predictPolicyValueBatchForPositions,
+  predictPolicyValueForMoves,
+} from './nnAI';
 
 const DEFAULT_CPUCT = 1.5;
 
@@ -38,6 +42,7 @@ class Node {
     this.children = [];
     this.visitCount = 0;
     this.valueSum = 0;
+    this.virtualVisits = 0;
   }
 
   get meanValue() {
@@ -47,11 +52,12 @@ class Node {
   selectChild(cpuct) {
     let best = null;
     let bestScore = -Infinity;
-    const parentVisits = Math.max(1, this.visitCount);
+    const parentVisits = Math.max(1, this.visitCount + this.virtualVisits);
 
     for (const child of this.children) {
       const q = child.visitCount === 0 ? 0 : -child.meanValue;
-      const u = cpuct * child.prior * Math.sqrt(parentVisits) / (1 + child.visitCount);
+      const effectiveVisits = child.visitCount + child.virtualVisits;
+      const u = cpuct * child.prior * Math.sqrt(parentVisits) / (1 + effectiveVisits);
       const score = q + u;
       if (score > bestScore) {
         bestScore = score;
@@ -97,6 +103,14 @@ class Node {
   }
 }
 
+function adjustVirtualVisits(node, amount) {
+  let current = node;
+  while (current) {
+    current.virtualVisits += amount;
+    current = current.parent;
+  }
+}
+
 async function evaluateAndExpand(node) {
   const terminal = terminalValue(node.pieces, node.toMove, node.enPassantTarget);
   if (terminal !== null) return terminal;
@@ -121,11 +135,59 @@ async function evaluateAndExpand(node) {
   return Number.isFinite(value) ? value : 0;
 }
 
+async function evaluateAndExpandBatch(nodes) {
+  const values = new Array(nodes.length);
+  const pending = [];
+
+  nodes.forEach((node, index) => {
+    const terminal = terminalValue(node.pieces, node.toMove, node.enPassantTarget);
+    if (terminal === null) {
+      pending.push({ node, index });
+    } else {
+      values[index] = terminal;
+    }
+  });
+
+  if (pending.length === 0) return values;
+
+  let predictions;
+  try {
+    if (typeof predictPolicyValueBatchForPositions !== 'function') throw new Error('batch inference unavailable');
+    predictions = await predictPolicyValueBatchForPositions(
+      pending.map(({ node }) => ({
+        pieces: node.pieces,
+        color: node.toMove,
+        enPassantTarget: node.enPassantTarget,
+      })),
+    );
+  } catch (error) {
+    predictions = await Promise.all(
+      pending.map(({ node }) => predictPolicyValueForMoves(
+        node.pieces,
+        node.toMove,
+        node.enPassantTarget,
+      ).catch(() => uniformPrediction(node.pieces, node.toMove, node.enPassantTarget))),
+    );
+  }
+
+  pending.forEach(({ node, index }, predictionIndex) => {
+    const prediction = predictions[predictionIndex] || uniformPrediction(
+      node.pieces,
+      node.toMove,
+      node.enPassantTarget,
+    );
+    node.expand(prediction.legalMoves, prediction.priors);
+    values[index] = Number.isFinite(prediction.value) ? prediction.value : 0;
+  });
+
+  return values;
+}
+
 export async function pickMCTSMove(
   pieces,
   color,
   enPassantTarget,
-  { timeMs = 1200, maxIterations = 3000, cpuct = DEFAULT_CPUCT } = {},
+  { timeMs = 2000, maxIterations = 4096, batchSize = 16, cpuct = DEFAULT_CPUCT } = {},
 ) {
   const root = new Node(null, clonePieces(pieces), color, enPassantTarget);
   const rootValue = await evaluateAndExpand(root);
@@ -136,16 +198,27 @@ export async function pickMCTSMove(
   const deadline = Date.now() + Math.max(1, timeMs);
   let iterations = 0;
   while (iterations < maxIterations && Date.now() < deadline) {
-    let node = root;
-    while (node.children.length > 0) {
-      node = node.selectChild(cpuct);
-      if (!node) break;
-    }
-    if (!node) break;
+    const selected = [];
+    const currentBatchSize = Math.min(Math.max(1, batchSize), maxIterations - iterations);
 
-    const value = await evaluateAndExpand(node);
-    node.backup(value);
-    iterations += 1;
+    for (let index = 0; index < currentBatchSize; index++) {
+      let node = root;
+      while (node.children.length > 0) {
+        node = node.selectChild(cpuct);
+        if (!node) break;
+      }
+      if (!node) break;
+      adjustVirtualVisits(node, 1);
+      selected.push(node);
+    }
+    if (selected.length === 0) break;
+
+    const values = await evaluateAndExpandBatch(selected);
+    selected.forEach((node, index) => {
+      adjustVirtualVisits(node, -1);
+      node.backup(values[index]);
+    });
+    iterations += selected.length;
   }
 
   const best = root.children.reduce((current, child) => {

--- a/src/ai/mctsAI.test.js
+++ b/src/ai/mctsAI.test.js
@@ -2,22 +2,33 @@ import { listLegalMoves } from '../rules/chessRules';
 
 jest.mock('./nnAI', () => ({
   moveKey: (move) => `${move.from.x}-${move.from.y}:${move.to.x}-${move.to.y}:${move.promotionType || ''}`,
+  predictPolicyValueBatchForPositions: jest.fn(),
   predictPolicyValueForMoves: jest.fn(),
 }));
 
-import { moveKey, predictPolicyValueForMoves } from './nnAI';
+import {
+  moveKey,
+  predictPolicyValueBatchForPositions,
+  predictPolicyValueForMoves,
+} from './nnAI';
 import { pickMCTSMove } from './mctsAI';
 
 const piece = (color, type, hasMoved = false) => ({ color, type, hasMoved });
 
 describe('neural PUCT MCTS', () => {
   beforeEach(() => {
-    predictPolicyValueForMoves.mockImplementation(async (pieces, color, enPassantTarget) => {
+    const predict = async (pieces, color, enPassantTarget) => {
       const legalMoves = listLegalMoves(pieces, color, enPassantTarget);
       const probability = 1 / Math.max(1, legalMoves.length);
       const priors = new Map(legalMoves.map((move) => [moveKey(move), probability]));
       return { value: 0, priors, legalMoves };
-    });
+    };
+    predictPolicyValueForMoves.mockImplementation(predict);
+    predictPolicyValueBatchForPositions.mockImplementation(
+      async (positions) => Promise.all(
+        positions.map(({ pieces, color, enPassantTarget }) => predict(pieces, color, enPassantTarget)),
+      ),
+    );
   });
 
   test('returns one of the legal moves', async () => {
@@ -32,10 +43,14 @@ describe('neural PUCT MCTS', () => {
     const chosen = await pickMCTSMove(pieces, 'white', null, {
       timeMs: 1000,
       maxIterations: 8,
+      batchSize: 4,
       cpuct: 1.5,
     });
 
-    expect(predictPolicyValueForMoves).toHaveBeenCalled();
+    expect(predictPolicyValueBatchForPositions).toHaveBeenCalled();
+    expect(
+      predictPolicyValueBatchForPositions.mock.calls.some(([positions]) => positions.length > 1),
+    ).toBe(true);
     expect(chosen).not.toBeNull();
     expect(
       legalMoves.some(

--- a/src/ai/nnAI.js
+++ b/src/ai/nnAI.js
@@ -55,8 +55,7 @@ function canCastleFromPieces(pieces, color, kingSide) {
   );
 }
 
-function featuresFromBoard(pieces, isWhiteTurn, enPassantTarget, planeCount = 18) {
-  const buf = tf.buffer([1, 8, 8, planeCount], 'float32');
+function writeBoardFeatures(buf, batchIndex, pieces, isWhiteTurn, enPassantTarget, planeCount) {
   const typeToIdx = { pawn: 0, knight: 1, bishop: 2, rook: 3, queen: 4, king: 5 };
 
   for (let y = 0; y < 8; y++) {
@@ -64,9 +63,9 @@ function featuresFromBoard(pieces, isWhiteTurn, enPassantTarget, planeCount = 18
       const piece = getPiece(pieces, y, x);
       if (piece) {
         const base = piece.color === 'white' ? 0 : 6;
-        buf.set(1, 0, y, x, base + typeToIdx[piece.type]);
+        buf.set(1, batchIndex, y, x, base + typeToIdx[piece.type]);
       }
-      buf.set(isWhiteTurn ? 1 : 0, 0, y, x, 12);
+      buf.set(isWhiteTurn ? 1 : 0, batchIndex, y, x, 12);
     }
   }
 
@@ -80,31 +79,58 @@ function featuresFromBoard(pieces, isWhiteTurn, enPassantTarget, planeCount = 18
     rights.forEach((available, offset) => {
       if (!available) return;
       for (let y = 0; y < 8; y++) {
-        for (let x = 0; x < 8; x++) buf.set(1, 0, y, x, 13 + offset);
+        for (let x = 0; x < 8; x++) buf.set(1, batchIndex, y, x, 13 + offset);
       }
     });
     if (enPassantTarget) {
-      buf.set(1, 0, enPassantTarget.x, enPassantTarget.y, 17);
+      buf.set(1, batchIndex, enPassantTarget.x, enPassantTarget.y, 17);
     }
   }
+}
+
+function featuresFromPositions(positions, planeCount = 18) {
+  const buf = tf.buffer([positions.length, 8, 8, planeCount], 'float32');
+  positions.forEach((position, index) => {
+    writeBoardFeatures(
+      buf,
+      index,
+      position.pieces,
+      position.color === 'white',
+      position.enPassantTarget,
+      planeCount,
+    );
+  });
 
   return buf.toTensor();
 }
 
-async function rawPrediction(model, pieces, isWhiteTurn, enPassantTarget) {
+async function rawPredictions(model, positions) {
   const planeCount = Number(model.inputs?.[0]?.shape?.[3]) || 18;
-  const x = featuresFromBoard(pieces, isWhiteTurn, enPassantTarget, planeCount);
+  const x = featuresFromPositions(positions, planeCount);
   const prediction = model.predict(x);
   const outputs = Array.isArray(prediction) ? prediction : [null, prediction];
   const [policyTensor, valueTensor] = outputs.length === 2 ? outputs : [null, outputs[0]];
 
   try {
-    const policyData = policyTensor ? Array.from(await policyTensor.data()) : null;
+    const policyData = policyTensor ? await policyTensor.data() : null;
     const valueData = await valueTensor.data();
-    return { policyData, value: valueData[0] };
+    const policySize = policyTensor ? Number(policyTensor.shape[policyTensor.shape.length - 1]) : 0;
+    return positions.map((_, index) => ({
+      policyData: policyData?.subarray(index * policySize, (index + 1) * policySize) || null,
+      value: valueData[index],
+    }));
   } finally {
     tf.dispose([x, ...outputs.filter(Boolean)]);
   }
+}
+
+async function rawPrediction(model, pieces, isWhiteTurn, enPassantTarget) {
+  const predictions = await rawPredictions(model, [{
+    pieces,
+    color: isWhiteTurn ? 'white' : 'black',
+    enPassantTarget,
+  }]);
+  return predictions[0];
 }
 
 async function evalPosition(model, pieces, isWhiteTurn, enPassantTarget) {
@@ -119,26 +145,53 @@ function uniformPrediction(legalMoves) {
   return { value: 0, priors, legalMoves };
 }
 
-export async function predictPolicyValueForMoves(pieces, color, enPassantTarget) {
-  const legalMoves = listLegalMoves(pieces, color, enPassantTarget);
-  if (legalMoves.length === 0) {
-    return { value: isKingInCheck(pieces, color) ? -1 : 0, priors: new Map(), legalMoves };
-  }
+function predictionForLegalMoves(legalMoves, raw) {
+  if (!raw.policyData) return { ...uniformPrediction(legalMoves), value: raw.value };
+  const logits = legalMoves.map((move) => raw.policyData[moveToPolicyIndex(move, raw.policyData.length)] ?? -1000000);
+  const probabilities = stableSoftmax(logits);
+  const priors = new Map();
+  legalMoves.forEach((move, index) => priors.set(moveKey(move), probabilities[index]));
+  return { value: raw.value, priors, legalMoves };
+}
+
+export async function predictPolicyValueBatchForPositions(positions) {
+  const results = new Array(positions.length);
+  const pending = [];
+
+  positions.forEach((position, index) => {
+    const legalMoves = listLegalMoves(position.pieces, position.color, position.enPassantTarget);
+    if (legalMoves.length === 0) {
+      results[index] = {
+        value: isKingInCheck(position.pieces, position.color) ? -1 : 0,
+        priors: new Map(),
+        legalMoves,
+      };
+    } else {
+      pending.push({ ...position, index, legalMoves });
+    }
+  });
+
+  if (pending.length === 0) return results;
 
   try {
     const model = await loadModel();
-    const { policyData, value } = await rawPrediction(model, pieces, color === 'white', enPassantTarget);
-    if (!policyData) return { ...uniformPrediction(legalMoves), value };
-
-    const logits = legalMoves.map((move) => policyData[moveToPolicyIndex(move, policyData.length)] ?? -1000000);
-    const probabilities = stableSoftmax(logits);
-    const priors = new Map();
-    legalMoves.forEach((move, index) => priors.set(moveKey(move), probabilities[index]));
-    return { value, priors, legalMoves };
+    const predictions = await rawPredictions(model, pending);
+    pending.forEach((position, pendingIndex) => {
+      results[position.index] = predictionForLegalMoves(position.legalMoves, predictions[pendingIndex]);
+    });
   } catch (error) {
     console.warn('Neural model unavailable; using uniform policy/value fallback.', error);
-    return uniformPrediction(legalMoves);
+    pending.forEach((position) => {
+      results[position.index] = uniformPrediction(position.legalMoves);
+    });
   }
+
+  return results;
+}
+
+export async function predictPolicyValueForMoves(pieces, color, enPassantTarget) {
+  const [prediction] = await predictPolicyValueBatchForPositions([{ pieces, color, enPassantTarget }]);
+  return prediction;
 }
 
 export async function pickNNMove(pieces, color, enPassantTarget, depth = 2) {


### PR DESCRIPTION
## What changed

- batch TensorFlow.js leaf evaluations during browser PUCT search
- use virtual visits so each browser inference batch explores multiple leaves
- raise the Neural MCTS move budget from 1.2 to 2 seconds
- generate self-play games concurrently with batched TensorFlow inference
- scale nightly self-play from 4 games at 80 searches to 16 games at 96 searches
- retain 20,000 self-play samples and train on up to 12,000 self-play plus 12,000 Stockfish positions per run
- expand the promotion arena from 2 games at 24 searches to 8 paired-color games at 48 searches
- serialize Pages deployments and use reproducible npm installs

## Why

The latest successful self-play run spent about 30 minutes generating 410 positions because every neural leaf was evaluated individually

Batching active games measured 2.1x faster than sequential search with the current checkpoint in a local four-board benchmark, allowing each workflow run to collect and revisit substantially more data within a bounded runtime

## Validation

- 8 Python AlphaZero regression tests
- 5 browser Jest tests
- production React build
- workflow YAML parse check
- real-checkpoint batch benchmark