### PR TITLE
Make nightly training prove chess strength gains

### DIFF
--- a/.github/workflows/nightly-self-play.yml
+++ b/.github/workflows/nightly-self-play.yml
@@ -31,27 +31,33 @@ jobs:
         run: python -m unittest discover -s ml/tests -p "test_*.py"
       - name: Generate neural MCTS self-play games
         env:
-          AZ_SELF_PLAY_GAMES: "16"
+          AZ_SELF_PLAY_GAMES: "24"
           AZ_SELF_PLAY_BATCH_SIZE: "8"
-          AZ_MCTS_SEARCHES: "96"
-          AZ_MAX_SELF_PLAY_SAMPLES: "20000"
+          AZ_MCTS_SEARCHES: "128"
+          AZ_MAX_SELF_PLAY_SAMPLES: "50000"
           AZ_SELF_PLAY_SEED: ${{ github.run_number }}
         run: python ml/self_play.py
       - name: Continue policy-value learning, evaluate, and export model
         env:
           TRAIN_SEED: ${{ github.run_number }}
-          AZ_MAX_SELF_PLAY_TRAIN: "12000"
-          AZ_MAX_STOCKFISH_TRAIN: "12000"
+          AZ_MAX_SELF_PLAY_TRAIN: "16000"
+          AZ_MAX_STOCKFISH_TRAIN: "24000"
+          AZ_STOCKFISH_POLICY_WEIGHT: "1.0"
+          AZ_MERGE_FRESH_STOCKFISH_LABELS: "0"
+          CONTINUE_EPOCHS: "4"
           AZ_ARENA_GAMES: "8"
-          AZ_ARENA_SEARCHES: "48"
+          AZ_ARENA_SEARCHES: "64"
           AZ_ARENA_MIN_SCORE: "0.5"
+          AZ_MCTS_EVAL_POSITIONS: "48"
+          AZ_MCTS_EVAL_SEARCHES: "64"
+          AZ_MIN_MCTS_ALIGNMENT_IMPROVEMENT: "0.0001"
         run: python ml/train_safe_export.py
       - name: Commit updated model state
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           bash scripts/stage_model_artifacts.sh ml/data/self_play_buffer.json
-          git add public/nn ml/checkpoints ml/data/self_play_buffer.json ml/data/fixed_eval_set_v2.json ml/training_history.json
+          git add public/nn ml/checkpoints ml/data/self_play_buffer.json ml/data/fixed_eval_set_v3.json ml/training_history.json
           if git diff --cached --quiet; then
             echo "No model changes to commit"
             exit 0

--- a/.github/workflows/nightly-train.yml
+++ b/.github/workflows/nightly-train.yml
@@ -46,31 +46,44 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Fetch Lichess games
+        env:
+          LICHESS_FETCH_SEED: ${{ github.run_number }}
+          LICHESS_USER_COUNT: "10"
+          LICHESS_MAX_GAMES: "300"
         run: python ml/fetch_lichess.py
       - name: Extract positions
         env:
           POSITION_SEED: ${{ github.run_number }}
+          POSITION_TARGET_NEW: "5000"
+          POSITION_MIN_NEW: "3000"
+          POSITION_PER_GAME: "32"
         run: python ml/extract_positions.py
       - name: Evaluate uncached positions with Stockfish
         env:
           SF_DEPTH: "12"
+          SF_MULTIPV: "3"
           STOCKFISH_PATH: stockfish
         run: python ml/stockfish_eval.py
       - name: Continue NN learning, evaluate, and export TFJS
         env:
           TRAIN_SEED: ${{ github.run_number }}
-          AZ_MAX_SELF_PLAY_TRAIN: "12000"
-          AZ_MAX_STOCKFISH_TRAIN: "12000"
+          AZ_MAX_SELF_PLAY_TRAIN: "16000"
+          AZ_MAX_STOCKFISH_TRAIN: "24000"
+          AZ_STOCKFISH_POLICY_WEIGHT: "1.0"
+          CONTINUE_EPOCHS: "4"
           AZ_ARENA_GAMES: "8"
-          AZ_ARENA_SEARCHES: "48"
+          AZ_ARENA_SEARCHES: "64"
           AZ_ARENA_MIN_SCORE: "0.5"
+          AZ_MCTS_EVAL_POSITIONS: "48"
+          AZ_MCTS_EVAL_SEARCHES: "64"
+          AZ_MIN_MCTS_ALIGNMENT_IMPROVEMENT: "0.0001"
         run: python ml/train_safe_export.py
       - name: Commit updated brain and browser model
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           bash scripts/stage_model_artifacts.sh ml/data/replay_buffer.json
-          git add public/nn ml/checkpoints ml/data/replay_buffer.json ml/data/fixed_eval_set_v2.json ml/training_history.json
+          git add public/nn ml/checkpoints ml/data/replay_buffer.json ml/data/fixed_eval_set_v3.json ml/training_history.json
           if git diff --cached --quiet; then
             echo "No model changes to commit"
             exit 0

--- a/ml/extract_positions.py
+++ b/ml/extract_positions.py
@@ -1,5 +1,6 @@
 # ml/extract_positions.py
-"""Read PGN and sample non-trivial positions into ml/data/positions.fen."""
+"""sample new non-trivial positions from PGN data"""
+import json
 import os
 import pathlib
 import random
@@ -7,23 +8,20 @@ import random
 import chess
 import chess.pgn
 
+from fen_utils import canonical_fen
+
 IN_PGN = pathlib.Path("ml/data/games.pgn")
 OUT_FEN = pathlib.Path("ml/data/positions.fen")
+REPLAY_JSON = pathlib.Path("ml/data/replay_buffer.json")
 SEED = int(os.environ.get("POSITION_SEED", "42"))
+TARGET_NEW = int(os.environ.get("POSITION_TARGET_NEW", "4000"))
+MIN_NEW = int(os.environ.get("POSITION_MIN_NEW", "1000"))
+MAX_GAMES = int(os.environ.get("POSITION_MAX_GAMES", "4000"))
+PER_GAME = int(os.environ.get("POSITION_PER_GAME", "32"))
 random.seed(SEED)
 
 
-def replay_to_ply(game, ply):
-    board = game.board()
-    for index, node in enumerate(game.mainline()):
-        if index > ply:
-            break
-        if node.move is not None:
-            board.push(node.move)
-    return board
-
-
-def sample_positions(pgn_path, max_games=2000, per_game=15, min_ply=12, max_ply=80):
+def sample_positions(pgn_path, max_games=MAX_GAMES, per_game=PER_GAME, min_ply=12, max_ply=100):
     count = 0
     skipped = 0
     with open(pgn_path, "r", encoding="utf-8") as handle:
@@ -39,10 +37,14 @@ def sample_positions(pgn_path, max_games=2000, per_game=15, min_ply=12, max_ply=
 
             plies = [ply for ply in range(min(len(nodes), max_ply)) if ply >= min_ply]
             random.shuffle(plies)
-            for ply in plies[:per_game]:
+            selected = set(plies[:per_game])
+            board = game.board()
+            for ply, node in enumerate(nodes):
                 try:
-                    board = replay_to_ply(game, ply)
-                    yield board.fen(en_passant="fen")
+                    if node.move is not None:
+                        board.push(node.move)
+                    if ply in selected:
+                        yield canonical_fen(board.fen(en_passant="fen"))
                 except (AssertionError, ValueError, chess.IllegalMoveError) as exc:
                     skipped += 1
                     print(f"[extract] skipped malformed position in game {count}, ply {ply}: {exc}")
@@ -54,13 +56,46 @@ def sample_positions(pgn_path, max_games=2000, per_game=15, min_ply=12, max_ply=
     print(f"[extract] processed {count} games with seed {SEED}; skipped {skipped}")
 
 
+def read_seen_fens() -> set[str]:
+    if not REPLAY_JSON.exists():
+        return set()
+    try:
+        items = json.loads(REPLAY_JSON.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return set()
+
+    seen = set()
+    for item in items if isinstance(items, list) else []:
+        fen = item.get("fen")
+        if not fen:
+            continue
+        try:
+            seen.add(canonical_fen(fen))
+        except ValueError:
+            continue
+    return seen
+
+
 def main():
     OUT_FEN.parent.mkdir(parents=True, exist_ok=True)
     positions = list(dict.fromkeys(sample_positions(IN_PGN)))
     if not positions:
         raise RuntimeError("no positions were extracted from the downloaded PGN")
-    OUT_FEN.write_text("\n".join(positions) + "\n", encoding="utf-8")
-    print(f"[extract] wrote {len(positions)} unique positions to {OUT_FEN}")
+
+    seen = read_seen_fens()
+    unseen = [fen for fen in positions if fen not in seen]
+    random.shuffle(unseen)
+    selected = unseen[:TARGET_NEW]
+    if len(selected) < MIN_NEW:
+        raise RuntimeError(
+            f"only {len(selected)} new positions found, below POSITION_MIN_NEW={MIN_NEW}"
+        )
+
+    OUT_FEN.write_text("\n".join(selected) + "\n", encoding="utf-8")
+    print(
+        f"[extract] candidates {len(positions)}, already seen {len(positions) - len(unseen)}, "
+        f"wrote {len(selected)} new positions to {OUT_FEN}"
+    )
 
 
 if __name__ == "__main__":

--- a/ml/fen_utils.py
+++ b/ml/fen_utils.py
@@ -1,0 +1,7 @@
+import chess
+
+
+def canonical_fen(fen: str) -> str:
+    board = chess.Board(fen)
+    fields = board.fen(en_passant="fen").split()
+    return " ".join((*fields[:4], "0", "1"))

--- a/ml/fetch_lichess.py
+++ b/ml/fetch_lichess.py
@@ -1,7 +1,9 @@
 # ml/fetch_lichess.py
-"""Download recent public Lichess games with retries and validation."""
+"""download diverse public Lichess games with retries and validation"""
+import datetime as dt
 import os
 import pathlib
+import random
 import time
 
 import requests
@@ -9,24 +11,75 @@ import requests
 OUT_PGN = pathlib.Path("ml/data/games.pgn")
 OUT_PGN.parent.mkdir(parents=True, exist_ok=True)
 
-DEFAULT_USERS = "drnykterstein,tsmftxh,alireza2003,rebeccaharris,crew64"
-USERS = [user.strip() for user in os.environ.get("LICHESS_USERS", DEFAULT_USERS).split(",") if user.strip()]
-MAX_GAMES = int(os.environ.get("LICHESS_MAX_GAMES", "1000"))
+FALLBACK_USERS = "alireza2003,rebeccaharris,crew64"
+USER_OVERRIDE = [user.strip() for user in os.environ.get("LICHESS_USERS", "").split(",") if user.strip()]
+LEADERBOARD_URL = "https://lichess.org/api/player/top/50/blitz"
+FETCH_SEED = int(os.environ.get("LICHESS_FETCH_SEED", "42"))
+USER_COUNT = int(os.environ.get("LICHESS_USER_COUNT", "10"))
+MAX_GAMES = int(os.environ.get("LICHESS_MAX_GAMES", "300"))
+HISTORY_WINDOWS = int(os.environ.get("LICHESS_HISTORY_WINDOWS", "52"))
+HISTORY_STRIDE_DAYS = int(os.environ.get("LICHESS_HISTORY_STRIDE_DAYS", "7"))
 RETRIES = int(os.environ.get("LICHESS_FETCH_RETRIES", "3"))
 TIMEOUT_SECONDS = float(os.environ.get("LICHESS_TIMEOUT_SECONDS", "30"))
-PARAMS = {"max": MAX_GAMES, "perfType": "blitz,rapid", "analysed": "false"}
 HEADERS = {
     "Accept": "application/x-chess-pgn",
     "User-Agent": "SuperRitchie-chess-training/1.0",
 }
 
 
-def fetch_user(session: requests.Session, username: str) -> str:
+def history_cutoff_ms() -> int:
+    window = FETCH_SEED % max(1, HISTORY_WINDOWS)
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=window * HISTORY_STRIDE_DAYS)
+    return int(cutoff.timestamp() * 1000)
+
+
+def discover_users(session: requests.Session) -> list[str]:
+    if USER_OVERRIDE:
+        return USER_OVERRIDE
+
+    try:
+        response = session.get(
+            LEADERBOARD_URL,
+            headers={**HEADERS, "Accept": "application/json"},
+            timeout=TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        users = response.json().get("users", [])
+        names = [user.get("username") or user.get("id") for user in users]
+        names = [name for name in names if name]
+        random.Random(FETCH_SEED).shuffle(names)
+        if names:
+            selected = names[:max(1, USER_COUNT)]
+            print(f"[lichess] selected {len(selected)} players from the live blitz leaderboard")
+            return selected
+    except (requests.RequestException, ValueError, AttributeError) as exc:
+        print(f"[lichess] warning: leaderboard discovery failed: {exc}")
+
+    fallback = [user.strip() for user in FALLBACK_USERS.split(",") if user.strip()]
+    print(f"[lichess] using {len(fallback)} fallback players")
+    return fallback
+
+
+def fetch_user(session: requests.Session, username: str, until_ms: int) -> str:
     url = f"https://lichess.org/api/games/user/{username}"
+    params = {
+        "max": MAX_GAMES,
+        "until": until_ms,
+        "perfType": "blitz,rapid",
+        "analysed": "false",
+        "clocks": "false",
+        "evals": "false",
+        "opening": "false",
+    }
     last_error = None
     for attempt in range(1, RETRIES + 1):
         try:
-            response = session.get(url, params=PARAMS, headers=HEADERS, timeout=TIMEOUT_SECONDS)
+            response = session.get(url, params=params, headers=HEADERS, timeout=TIMEOUT_SECONDS)
+            if response.status_code == 429 and attempt < RETRIES:
+                retry_after = max(60, int(response.headers.get("Retry-After", "60")))
+                print(f"[lichess] {username} rate limited, waiting {retry_after}s")
+                time.sleep(retry_after)
+                continue
             response.raise_for_status()
             text = response.text.strip()
             if not text:
@@ -41,15 +94,17 @@ def fetch_user(session: requests.Session, username: str) -> str:
 
 
 def main():
-    if not USERS:
-        raise RuntimeError("LICHESS_USERS resolved to an empty user list")
-
     downloaded = []
     with requests.Session() as session:
-        for username in USERS:
+        users = discover_users(session)
+        if not users:
+            raise RuntimeError("Lichess player list resolved to empty")
+        until_ms = history_cutoff_ms()
+        print(f"[lichess] historical cutoff {until_ms} from seed {FETCH_SEED}")
+        for username in users:
             print(f"[lichess] fetching {username}")
             try:
-                downloaded.append(fetch_user(session, username))
+                downloaded.append(fetch_user(session, username, until_ms))
             except RuntimeError as exc:
                 print(f"[lichess] warning: {exc}")
             time.sleep(1.0)
@@ -58,7 +113,8 @@ def main():
         raise RuntimeError("all Lichess downloads failed; refusing to overwrite the dataset")
 
     OUT_PGN.write_text("\n\n".join(downloaded) + "\n", encoding="utf-8")
-    print(f"[lichess] wrote PGN data from {len(downloaded)}/{len(USERS)} users to {OUT_PGN}")
+    game_count = sum(text.count("[Event ") for text in downloaded)
+    print(f"[lichess] wrote {game_count} games from {len(downloaded)}/{len(users)} players to {OUT_PGN}")
 
 
 if __name__ == "__main__":

--- a/ml/stockfish_eval.py
+++ b/ml/stockfish_eval.py
@@ -1,21 +1,42 @@
 # ml/stockfish_eval.py
-"""Evaluate only uncached FENs with one persistent Stockfish process."""
+"""evaluate uncached positions and expert move policies with Stockfish"""
 import json
+import math
 import os
 import pathlib
 
 import chess
 import chess.engine
 
+from fen_utils import canonical_fen
+from policy_map import POLICY_VERSION, move_to_index
+
 IN_FEN = pathlib.Path("ml/data/positions.fen")
 OUT_JSON = pathlib.Path("ml/data/labels.json")
 REPLAY_JSON = pathlib.Path("ml/data/replay_buffer.json")
 STOCKFISH = os.environ.get("STOCKFISH_PATH", "stockfish")
 DEPTH = int(os.environ.get("SF_DEPTH", "12"))
+MULTIPV = int(os.environ.get("SF_MULTIPV", "3"))
+POLICY_TEMPERATURE_CP = float(os.environ.get("SF_POLICY_TEMPERATURE_CP", "120"))
 MATE_SCORE = 100000
 
 
-def read_cached_labels() -> dict[str, float]:
+def valid_policy(item: dict) -> bool:
+    policy = item.get("policy")
+    if not isinstance(policy, list):
+        return False
+    for entry in policy:
+        if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+            continue
+        try:
+            if float(entry[1]) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
+def read_cached_labels() -> dict[str, dict]:
     if not REPLAY_JSON.exists():
         return {}
     try:
@@ -29,7 +50,13 @@ def read_cached_labels() -> dict[str, float]:
         if not fen:
             continue
         try:
-            cache[fen] = float(item.get("cp", 0.0))
+            normalized_fen = canonical_fen(fen)
+            cache[normalized_fen] = {
+                "fen": normalized_fen,
+                "cp": float(item.get("cp", 0.0)),
+                "policy_version": int(item.get("policy_version", 1)),
+                "policy": item.get("policy", []),
+            }
         except (TypeError, ValueError):
             continue
     return cache
@@ -44,26 +71,58 @@ def read_unique_fens() -> list[str]:
             if not fen or fen in seen:
                 continue
             try:
-                chess.Board(fen)
+                normalized_fen = canonical_fen(fen)
             except ValueError as exc:
                 print(f"[stockfish] skipped malformed FEN: {exc}")
                 continue
-            seen.add(fen)
-            unique.append(fen)
+            if normalized_fen in seen:
+                continue
+            seen.add(normalized_fen)
+            unique.append(normalized_fen)
     return unique
 
 
-def analyse_position(engine: chess.engine.SimpleEngine, fen: str) -> float:
+def analyse_position(engine: chess.engine.SimpleEngine, fen: str) -> dict:
     board = chess.Board(fen)
-    info = engine.analyse(board, chess.engine.Limit(depth=DEPTH))
-    score = info["score"].pov(board.turn).score(mate_score=MATE_SCORE)
-    return float(score if score is not None else 0.0)
+    infos = engine.analyse(
+        board,
+        chess.engine.Limit(depth=DEPTH),
+        multipv=max(1, MULTIPV),
+    )
+    if isinstance(infos, dict):
+        infos = [infos]
+
+    candidates = []
+    for info in infos:
+        pv = info.get("pv") or []
+        if not pv:
+            continue
+        score = info["score"].pov(board.turn).score(mate_score=MATE_SCORE)
+        candidates.append((pv[0], float(score if score is not None else 0.0)))
+    if not candidates:
+        raise ValueError("Stockfish returned no principal variation")
+
+    candidates.sort(key=lambda item: item[1], reverse=True)
+    best_score = candidates[0][1]
+    temperature = max(1.0, POLICY_TEMPERATURE_CP)
+    weights = [math.exp(max(-40.0, (score - best_score) / temperature)) for _, score in candidates]
+    total = sum(weights)
+    policy = [
+        [move_to_index(move), weight / total]
+        for (move, _), weight in zip(candidates, weights)
+    ]
+    return {
+        "fen": canonical_fen(fen),
+        "cp": best_score,
+        "policy_version": POLICY_VERSION,
+        "policy": policy,
+    }
 
 
 def main():
     fens = read_unique_fens()
     cache = read_cached_labels()
-    missing = [fen for fen in fens if fen not in cache]
+    missing = [fen for fen in fens if fen not in cache or not valid_policy(cache[fen])]
     print(f"[stockfish] positions {len(fens)}, cache hits {len(fens) - len(missing)}, new {len(missing)}")
 
     if missing:
@@ -80,7 +139,7 @@ def main():
         finally:
             engine.quit()
 
-    data = [{"fen": fen, "cp": cache[fen]} for fen in fens if fen in cache]
+    data = [cache[fen] for fen in fens if fen in cache and valid_policy(cache[fen])]
     if not data:
         raise RuntimeError("Stockfish evaluation produced no labels")
 

--- a/ml/tests/test_alpha_zero_core.py
+++ b/ml/tests/test_alpha_zero_core.py
@@ -1,8 +1,12 @@
+import json
 import pathlib
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 import chess
+import chess.engine
 import numpy as np
 
 ML_DIR = pathlib.Path(__file__).resolve().parents[1]
@@ -10,8 +14,10 @@ if str(ML_DIR) not in sys.path:
     sys.path.insert(0, str(ML_DIR))
 
 import features
+import fen_utils
 import policy_map
 import self_play
+import stockfish_eval
 import train
 
 
@@ -51,6 +57,61 @@ class FeatureTests(unittest.TestCase):
         col = chess.square_file(chess.F3)
         self.assertEqual(encoded[row, col, 17], 1.0)
         self.assertEqual(float(np.sum(encoded[:, :, 17])), 1.0)
+
+
+class DataPipelineTests(unittest.TestCase):
+    def test_canonical_fen_removes_move_counters(self):
+        first = "8/8/8/8/8/8/4K3/7k w - - 17 48"
+        second = "8/8/8/8/8/8/4K3/7k w - - 0 1"
+        self.assertEqual(fen_utils.canonical_fen(first), fen_utils.canonical_fen(second))
+
+    def test_stockfish_analysis_creates_policy_target(self):
+        class FakeEngine:
+            def analyse(self, board, limit, multipv):
+                return [
+                    {
+                        "score": chess.engine.PovScore(chess.engine.Cp(score), chess.WHITE),
+                        "pv": [chess.Move.from_uci(move)],
+                    }
+                    for move, score in (("e2e4", 80), ("d2d4", 50), ("g1f3", 20))
+                ]
+
+        label = stockfish_eval.analyse_position(FakeEngine(), chess.STARTING_FEN)
+
+        self.assertEqual(label["policy_version"], policy_map.POLICY_VERSION)
+        self.assertEqual(len(label["policy"]), 3)
+        self.assertAlmostEqual(sum(item[1] for item in label["policy"]), 1.0)
+        self.assertEqual(label["policy"][0][0], policy_map.move_to_index(chess.Move.from_uci("e2e4")))
+
+    def test_replay_freshness_counts_only_unseen_positions(self):
+        first_fen = fen_utils.canonical_fen(chess.STARTING_FEN)
+        board = chess.Board()
+        board.push_uci("e2e4")
+        second_fen = fen_utils.canonical_fen(board.fen(en_passant="fen"))
+        first_policy = [[policy_map.move_to_index(chess.Move.from_uci("e2e4")), 1.0]]
+        with tempfile.TemporaryDirectory() as directory:
+            replay_path = pathlib.Path(directory) / "replay.json"
+            replay_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "fen": first_fen,
+                            "cp": 0,
+                            "policy_version": policy_map.POLICY_VERSION,
+                            "policy": first_policy,
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            with mock.patch.object(train, "STOCKFISH_REPLAY_BUFFER", replay_path):
+                merged, novel_count = train.merge_stockfish_replay_buffer(
+                    [{"fen": first_fen, "cp": 10}, {"fen": second_fen, "cp": 20}]
+                )
+
+        self.assertEqual(novel_count, 1)
+        self.assertEqual({item["fen"] for item in merged}, {first_fen, second_fen})
+        self.assertEqual(next(item for item in merged if item["fen"] == first_fen)["policy"], first_policy)
 
 
 class SearchAndModelTests(unittest.TestCase):

--- a/ml/train.py
+++ b/ml/train.py
@@ -13,6 +13,7 @@ import numpy as np
 import tensorflow as tf
 
 from features import PLANES, board_to_features
+from fen_utils import canonical_fen
 from policy_map import (
     LEGACY_POLICY_SIZE,
     POLICY_CHANNELS,
@@ -43,6 +44,8 @@ COLD_START_LR = float(os.environ.get("COLD_START_LR", "1e-3"))
 CONTINUE_LR = float(os.environ.get("CONTINUE_LR", "2e-4"))
 MIN_VALIDATION_IMPROVEMENT = float(os.environ.get("AZ_MIN_VALIDATION_IMPROVEMENT", "0.0001"))
 STOCKFISH_VALUE_WEIGHT = float(os.environ.get("AZ_STOCKFISH_VALUE_WEIGHT", "1.0"))
+STOCKFISH_POLICY_WEIGHT = float(os.environ.get("AZ_STOCKFISH_POLICY_WEIGHT", "1.0"))
+MERGE_FRESH_STOCKFISH_LABELS = os.environ.get("AZ_MERGE_FRESH_STOCKFISH_LABELS", "1") != "0"
 TRAIN_SEED = int(os.environ.get("TRAIN_SEED", "42"))
 
 random.seed(TRAIN_SEED)
@@ -65,6 +68,26 @@ def write_json(path: pathlib.Path, data) -> None:
     path.write_text(json.dumps(data, separators=(",", ":")), encoding="utf-8")
 
 
+def normalize_sparse_policy(policy_items, fen: str, policy_version: int) -> list[list[float]]:
+    board = chess.Board(fen)
+    by_index = {}
+    for item in policy_items or []:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            continue
+        try:
+            index = normalize_policy_index(int(item[0]), board, policy_version)
+            probability = float(item[1])
+        except (TypeError, ValueError):
+            continue
+        if probability > 0 and np.isfinite(probability):
+            by_index[index] = by_index.get(index, 0.0) + probability
+
+    total = sum(by_index.values())
+    if total <= 0:
+        return []
+    return [[index, probability / total] for index, probability in sorted(by_index.items())]
+
+
 def normalize_labels(items: list[dict]) -> list[dict]:
     normalized = []
     for item in items:
@@ -72,22 +95,38 @@ def normalize_labels(items: list[dict]) -> list[dict]:
         if not fen:
             continue
         try:
+            fen = canonical_fen(fen)
             cp = float(item.get("cp", 0.0))
+            policy_version = int(item.get("policy_version", 1))
         except (TypeError, ValueError):
             continue
-        normalized.append({"fen": fen, "cp": cp})
+        policy = normalize_sparse_policy(item.get("policy"), fen, policy_version)
+        normalized.append(
+            {
+                "fen": fen,
+                "cp": cp,
+                "policy_version": POLICY_VERSION if policy else policy_version,
+                "policy": policy,
+            }
+        )
     return normalized
 
 
-def merge_stockfish_replay_buffer(new_items: list[dict]) -> list[dict]:
+def merge_stockfish_replay_buffer(new_items: list[dict]) -> tuple[list[dict], int]:
     existing_items = normalize_labels(read_json_list(STOCKFISH_REPLAY_BUFFER))
     new_items = normalize_labels(new_items)
 
-    by_fen = {item["fen"]: item for item in existing_items}
-    for item in new_items:
+    existing_by_fen = {item["fen"]: item for item in existing_items}
+    new_by_fen = {item["fen"]: item for item in new_items}
+    novel_count = sum(fen not in existing_by_fen for fen in new_by_fen)
+    by_fen = dict(existing_by_fen)
+    for fen, item in list(new_by_fen.items()):
+        existing = by_fen.get(item["fen"])
+        if existing and existing.get("policy") and not item.get("policy"):
+            item = {**item, "policy_version": existing["policy_version"], "policy": existing["policy"]}
+        new_by_fen[fen] = item
         by_fen[item["fen"]] = item
 
-    new_by_fen = {item["fen"]: item for item in new_items}
     if len(new_by_fen) >= MAX_REPLAY_ITEMS:
         merged = list(new_by_fen.values())
         random.shuffle(merged)
@@ -100,8 +139,12 @@ def merge_stockfish_replay_buffer(new_items: list[dict]) -> list[dict]:
 
     random.shuffle(merged)
     write_json(STOCKFISH_REPLAY_BUFFER, merged)
-    print(f"[train] Stockfish replay buffer {len(merged)} positions, new {len(new_items)}")
-    return merged
+    policy_count = sum(bool(item.get("policy")) for item in merged)
+    print(
+        f"[train] Stockfish replay buffer {len(merged)} positions, "
+        f"incoming {len(new_by_fen)}, truly new {novel_count}, policy targets {policy_count}"
+    )
+    return merged, novel_count
 
 
 def cp_to_value(cp: float) -> float:
@@ -155,19 +198,29 @@ def load_self_play_samples(excluded_fens: set[str] | None = None):
 
 def load_stockfish_samples(excluded_fens: set[str] | None = None):
     excluded_fens = excluded_fens or set()
-    fresh_items = normalize_labels(read_json_list(LABELS))
-    all_items = merge_stockfish_replay_buffer(fresh_items)
+    fresh_items = normalize_labels(read_json_list(LABELS)) if MERGE_FRESH_STOCKFISH_LABELS else []
+    all_items, novel_count = merge_stockfish_replay_buffer(fresh_items)
     items = [item for item in all_items if item["fen"] not in excluded_fens][-MAX_STOCKFISH_TRAIN:]
-    X, values = [], []
+    X, policies, values, policy_weights = [], [], [], []
     for item in items:
         X.append(board_to_features(item["fen"]))
+        policy = dense_policy_from_sparse(
+            item.get("policy"),
+            fen=item["fen"],
+            policy_version=int(item.get("policy_version", POLICY_VERSION)),
+        )
+        policies.append(policy)
+        policy_weights.append(STOCKFISH_POLICY_WEIGHT if float(np.sum(policy)) > 0 else 0.0)
         values.append(cp_to_value(float(item["cp"])))
-    return X, values, len(fresh_items), len(items)
+    print(f"[train] using {sum(weight > 0 for weight in policy_weights)} Stockfish policy targets")
+    return X, policies, values, policy_weights, novel_count, len(items)
 
 
 def load_dataset(excluded_fens: set[str] | None = None):
     self_X, self_policy, self_value = load_self_play_samples(excluded_fens)
-    stock_X, stock_value, fresh_count, stockfish_count = load_stockfish_samples(excluded_fens)
+    stock_X, stock_policy, stock_value, stock_policy_weights, fresh_count, stockfish_count = load_stockfish_samples(
+        excluded_fens
+    )
 
     X = []
     policy_y = []
@@ -182,12 +235,16 @@ def load_dataset(excluded_fens: set[str] | None = None):
         policy_weights.append(1.0)
         value_weights.append(1.0)
 
-    zero_policy = np.zeros((POLICY_SIZE,), dtype=np.float32)
-    for features, value in zip(stock_X, stock_value):
+    for features, policy, value, policy_weight in zip(
+        stock_X,
+        stock_policy,
+        stock_value,
+        stock_policy_weights,
+    ):
         X.append(features)
-        policy_y.append(zero_policy.copy())
+        policy_y.append(policy)
         value_y.append(value)
-        policy_weights.append(0.0)
+        policy_weights.append(policy_weight)
         value_weights.append(STOCKFISH_VALUE_WEIGHT)
 
     if not X:

--- a/ml/train_fixed_eval.py
+++ b/ml/train_fixed_eval.py
@@ -1,21 +1,25 @@
 # ml/train_fixed_eval.py
-"""Train with a persistent holdout set and an optional model-vs-model arena."""
+"""train with persistent neural and search-quality holdouts"""
 import os
 import random
 
+import chess
 import numpy as np
 import tensorflow as tf
 
 import train
-from self_play import arena_score
+from self_play import arena_score, run_search_batch
 
-FIXED_EVAL_SET = train.pathlib.Path("ml/data/fixed_eval_set_v2.json")
+FIXED_EVAL_SET = train.pathlib.Path("ml/data/fixed_eval_set_v3.json")
 FIXED_EVAL_SELF = int(os.environ.get("AZ_FIXED_EVAL_SELF", "512"))
 FIXED_EVAL_STOCKFISH = int(os.environ.get("AZ_FIXED_EVAL_STOCKFISH", "512"))
 ARENA_GAMES = int(os.environ.get("AZ_ARENA_GAMES", "2"))
 ARENA_SEARCHES = int(os.environ.get("AZ_ARENA_SEARCHES", "24"))
 ARENA_MAX_PLIES = int(os.environ.get("AZ_ARENA_MAX_PLIES", "160"))
 ARENA_MIN_SCORE = float(os.environ.get("AZ_ARENA_MIN_SCORE", "0.5"))
+MCTS_EVAL_POSITIONS = int(os.environ.get("AZ_MCTS_EVAL_POSITIONS", "48"))
+MCTS_EVAL_SEARCHES = int(os.environ.get("AZ_MCTS_EVAL_SEARCHES", "64"))
+MIN_MCTS_ALIGNMENT_IMPROVEMENT = float(os.environ.get("AZ_MIN_MCTS_ALIGNMENT_IMPROVEMENT", "0.0001"))
 _EPS = 1e-7
 
 
@@ -48,7 +52,17 @@ def _valid_stockfish_sample(item: dict) -> dict | None:
         cp = float(item.get("cp", 0.0))
     except (TypeError, ValueError):
         return None
-    return {"source": "stockfish", "fen": fen, "cp": cp}
+    policy_version = int(item.get("policy_version", 1))
+    policy = train.dense_policy_from_sparse(item.get("policy"), fen=fen, policy_version=policy_version)
+    if float(np.sum(policy)) <= 0:
+        return None
+    return {
+        "source": "stockfish",
+        "fen": fen,
+        "cp": cp,
+        "policy_version": policy_version,
+        "policy": item.get("policy"),
+    }
 
 
 def _pick_deterministic(items: list[dict], count: int, salt: str) -> list[dict]:
@@ -65,14 +79,15 @@ def create_fixed_eval_set() -> list[dict]:
         if sample is not None:
             self_items.append(sample)
 
-    stockfish_items = []
-    for item in train.normalize_labels(train.read_json_list(train.STOCKFISH_REPLAY_BUFFER)):
+    stockfish_by_fen = {}
+    source_items = train.read_json_list(train.STOCKFISH_REPLAY_BUFFER) + train.read_json_list(train.LABELS)
+    for item in train.normalize_labels(source_items):
         sample = _valid_stockfish_sample(item)
         if sample is not None:
-            stockfish_items.append(sample)
+            stockfish_by_fen[sample["fen"]] = sample
 
     fixed_items = _pick_deterministic(self_items, FIXED_EVAL_SELF, "self-v2")
-    fixed_items += _pick_deterministic(stockfish_items, FIXED_EVAL_STOCKFISH, "stockfish-v2")
+    fixed_items += _pick_deterministic(list(stockfish_by_fen.values()), FIXED_EVAL_STOCKFISH, "stockfish-v3")
     if not fixed_items:
         raise ValueError("could not create fixed evaluation set: no valid samples")
 
@@ -84,7 +99,8 @@ def create_fixed_eval_set() -> list[dict]:
 
 def load_fixed_eval_set() -> list[dict]:
     items = train.read_json_list(FIXED_EVAL_SET)
-    return items if items else create_fixed_eval_set()
+    stockfish_count = sum(item.get("source") == "stockfish" for item in items)
+    return items if items and stockfish_count > 0 else create_fixed_eval_set()
 
 
 def fixed_eval_arrays(samples: list[dict]):
@@ -95,8 +111,6 @@ def fixed_eval_arrays(samples: list[dict]):
     value_weights = []
     self_count = 0
     stockfish_count = 0
-    zero_policy = np.zeros((train.POLICY_SIZE,), dtype=np.float32)
-
     for sample in samples:
         source = sample.get("source")
         fen = sample.get("fen")
@@ -126,10 +140,17 @@ def fixed_eval_arrays(samples: list[dict]):
                 cp = float(sample.get("cp", 0.0))
             except (TypeError, ValueError):
                 continue
+            policy = train.dense_policy_from_sparse(
+                sample.get("policy"),
+                fen=fen,
+                policy_version=int(sample.get("policy_version", train.POLICY_VERSION)),
+            )
+            if float(np.sum(policy)) <= 0:
+                continue
             X.append(train.board_to_features(fen))
-            policy_y.append(zero_policy.copy())
+            policy_y.append(policy)
             value_y.append(train.cp_to_value(cp))
-            policy_weights.append(0.0)
+            policy_weights.append(1.0)
             value_weights.append(1.0)
             stockfish_count += 1
 
@@ -199,6 +220,63 @@ def evaluate_fixed_model(model: tf.keras.Model | None, X, P, V, PW, VW, label: s
     return metrics
 
 
+def evaluate_mcts_alignment(model: tf.keras.Model | None, samples: list[dict], label: str) -> dict | None:
+    if model is None or MCTS_EVAL_POSITIONS <= 0:
+        return None
+
+    boards = []
+    targets = []
+    for sample in samples:
+        if sample.get("source") != "stockfish":
+            continue
+        fen = sample.get("fen")
+        if not fen:
+            continue
+        target = train.dense_policy_from_sparse(
+            sample.get("policy"),
+            fen=fen,
+            policy_version=int(sample.get("policy_version", train.POLICY_VERSION)),
+        )
+        if float(np.sum(target)) <= 0:
+            continue
+        try:
+            boards.append(chess.Board(fen))
+        except ValueError:
+            continue
+        targets.append(target)
+        if len(boards) >= MCTS_EVAL_POSITIONS:
+            break
+
+    if not boards:
+        print(f"[mcts-eval] {label} unavailable: no Stockfish policy holdout")
+        return None
+
+    search_policies = run_search_batch(
+        model,
+        boards,
+        searches=MCTS_EVAL_SEARCHES,
+        add_noise=False,
+    )
+    alignments = []
+    top_move_hits = []
+    for search_policy, target in zip(search_policies, targets):
+        alignments.append(sum(float(target[index]) * probability for index, probability in search_policy.items()))
+        chosen = max(search_policy, key=search_policy.get)
+        top_move_hits.append(chosen == int(np.argmax(target)))
+
+    metrics = {
+        "positions": len(boards),
+        "searches": MCTS_EVAL_SEARCHES,
+        "alignment": float(np.mean(alignments)),
+        "top_move_accuracy": float(np.mean(top_move_hits)),
+    }
+    print(
+        f"[mcts-eval] {label} alignment {metrics['alignment']:.6f}, "
+        f"top move {metrics['top_move_accuracy']:.3f} over {len(boards)} positions"
+    )
+    return metrics
+
+
 def main():
     fixed_samples = load_fixed_eval_set()
     excluded_fens = {item.get("fen") for item in fixed_samples if item.get("fen")}
@@ -239,6 +317,22 @@ def main():
     moving_candidate_eval = train.evaluate_model(model, Xva, Pva, Vva, PWva, VWva, "candidate moving")
     fixed_candidate_eval = evaluate_fixed_model(model, Xev, Pev, Vev, PWev, VWev, "candidate fixed")
     accepted, gate_reason = train.should_accept_candidate(fixed_candidate_eval, fixed_baseline_eval, resumed)
+
+    baseline_mcts_eval = None
+    candidate_mcts_eval = None
+    if accepted and resumed:
+        baseline_mcts_eval = evaluate_mcts_alignment(baseline_model, fixed_samples, "previous")
+        candidate_mcts_eval = evaluate_mcts_alignment(model, fixed_samples, "candidate")
+        if baseline_mcts_eval is None or candidate_mcts_eval is None:
+            accepted = False
+            gate_reason = "candidate_mcts_evaluation_unavailable"
+        else:
+            required_alignment = baseline_mcts_eval["alignment"] + MIN_MCTS_ALIGNMENT_IMPROVEMENT
+            if candidate_mcts_eval["alignment"] < required_alignment:
+                accepted = False
+                gate_reason = "candidate_mcts_alignment_did_not_improve"
+            else:
+                gate_reason = f"{gate_reason}_and_mcts_improved"
 
     arena_result = None
     if accepted and resumed and baseline_model is not None and ARENA_GAMES > 0:
@@ -281,6 +375,18 @@ def main():
                 "arena_searches": ARENA_SEARCHES,
                 "arena_candidate_score": arena_result,
                 "arena_min_score": ARENA_MIN_SCORE,
+            }
+        )
+    if baseline_mcts_eval and candidate_mcts_eval:
+        extra_metrics.update(
+            {
+                "mcts_eval_positions": candidate_mcts_eval["positions"],
+                "mcts_eval_searches": candidate_mcts_eval["searches"],
+                "baseline_mcts_alignment": baseline_mcts_eval["alignment"],
+                "candidate_mcts_alignment": candidate_mcts_eval["alignment"],
+                "baseline_mcts_top_move_accuracy": baseline_mcts_eval["top_move_accuracy"],
+                "candidate_mcts_top_move_accuracy": candidate_mcts_eval["top_move_accuracy"],
+                "min_mcts_alignment_improvement": MIN_MCTS_ALIGNMENT_IMPROVEMENT,
             }
         )
 

--- a/scripts/stage_model_artifacts.sh
+++ b/scripts/stage_model_artifacts.sh
@@ -10,7 +10,7 @@ mkdir -p "$artifact_dir/public" "$artifact_dir/ml/checkpoints" "$(dirname "$arti
 cp -a public/nn "$artifact_dir/public/"
 cp -a ml/checkpoints/. "$artifact_dir/ml/checkpoints/"
 cp -a "$buffer_path" "$artifact_dir/$buffer_path"
-cp -a ml/data/fixed_eval_set_v2.json "$artifact_dir/ml/data/fixed_eval_set_v2.json"
+cp -a ml/data/fixed_eval_set_v3.json "$artifact_dir/ml/data/fixed_eval_set_v3.json"
 cp -a ml/training_history.json "$artifact_dir/ml/training_history.json"
 
 git fetch origin master
@@ -31,5 +31,5 @@ cp -a "$artifact_dir/public/nn" public/
 mkdir -p ml/checkpoints
 cp -a "$artifact_dir/ml/checkpoints/." ml/checkpoints/
 cp -a "$artifact_dir/$buffer_path" "$buffer_path"
-cp -a "$artifact_dir/ml/data/fixed_eval_set_v2.json" ml/data/fixed_eval_set_v2.json
+cp -a "$artifact_dir/ml/data/fixed_eval_set_v3.json" ml/data/fixed_eval_set_v3.json
 cp -a "$artifact_dir/ml/training_history.json" ml/training_history.json

--- a/src/ai/mctsAI.js
+++ b/src/ai/mctsAI.js
@@ -195,6 +195,11 @@ export async function pickMCTSMove(
   root.valueSum = rootValue;
   if (root.children.length === 0) return null;
 
+  const immediateMate = root.children.find(
+    (child) => terminalValue(child.pieces, child.toMove, child.enPassantTarget) === -1,
+  );
+  if (immediateMate) return immediateMate.move;
+
   const deadline = Date.now() + Math.max(1, timeMs);
   let iterations = 0;
   while (iterations < maxIterations && Date.now() < deadline) {

--- a/src/ai/mctsAI.test.js
+++ b/src/ai/mctsAI.test.js
@@ -17,6 +17,7 @@ const piece = (color, type, hasMoved = false) => ({ color, type, hasMoved });
 
 describe('neural PUCT MCTS', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     const predict = async (pieces, color, enPassantTarget) => {
       const legalMoves = listLegalMoves(pieces, color, enPassantTarget);
       const probability = 1 / Math.max(1, legalMoves.length);
@@ -62,5 +63,23 @@ describe('neural PUCT MCTS', () => {
           (move.promotionType || null) === (chosen.promotionType || null),
       ),
     ).toBe(true);
+  });
+
+  test('plays an available checkmate before neural search', async () => {
+    const pieces = {
+      '0-0': piece('black', 'king'),
+      '2-2': piece('white', 'king'),
+      '2-1': piece('white', 'queen'),
+    };
+
+    const chosen = await pickMCTSMove(pieces, 'white', null, {
+      timeMs: 1000,
+      maxIterations: 1,
+      batchSize: 1,
+    });
+
+    expect(chosen.from).toEqual({ x: 2, y: 1 });
+    expect(chosen.to).toEqual({ x: 1, y: 1 });
+    expect(predictPolicyValueBatchForPositions).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

- Nightly runs #382 through #385 reused the same 1,034 games while fresh Stockfish labels fell from 1,103 to 526
- Two of five hard-coded Lichess accounts returned empty data
- Training history counted all downloaded labels as fresh even when most were cache hits
- The last 32 arena games were draws, so a score of 0.500 did not prove stronger play
- Stockfish labels trained only the value head while the policy head mostly imitated drawn self-play

## Changes

- Sample 10 players from the live Lichess blitz leaderboard and rotate through historical cutoffs
- Require 3,000 fresh positions and target 5,000 per nightly run
- Canonicalize FENs so move counters cannot create duplicate training samples
- Generate MultiPV Stockfish policy targets and train both policy and value heads
- Track truly new replay positions instead of downloaded label count
- Add a persistent Stockfish policy holdout and require MCTS alignment to improve before promotion
- Increase supervised training to 40,000 positions and four continuation epochs
- Increase self-play to 24 games with 128 searches and a 50,000-position buffer
- Make browser MCTS play an available checkmate immediately

## Validation

- 11 Python tests pass
- 6 browser tests pass
- Production build passes
- Published branch tree matches the locally reviewed commit