### PR TITLE
Make live NN and MCTS play stronger

### DIFF
--- a/.github/workflows/nightly-self-play.yml
+++ b/.github/workflows/nightly-self-play.yml
@@ -45,12 +45,13 @@ jobs:
           AZ_STOCKFISH_POLICY_WEIGHT: "1.0"
           AZ_MERGE_FRESH_STOCKFISH_LABELS: "0"
           CONTINUE_EPOCHS: "4"
-          AZ_ARENA_GAMES: "8"
+          AZ_ARENA_GAMES: "16"
           AZ_ARENA_SEARCHES: "64"
-          AZ_ARENA_MIN_SCORE: "0.5"
-          AZ_MCTS_EVAL_POSITIONS: "48"
+          AZ_ARENA_MIN_SCORE: "0.55"
+          AZ_MCTS_EVAL_POSITIONS: "192"
           AZ_MCTS_EVAL_SEARCHES: "64"
           AZ_MIN_MCTS_ALIGNMENT_IMPROVEMENT: "0.0001"
+          AZ_MIN_MCTS_TOP_MOVE_IMPROVEMENT: "0.0"
         run: python ml/train_safe_export.py
       - name: Commit updated model state
         run: |

--- a/.github/workflows/nightly-train.yml
+++ b/.github/workflows/nightly-train.yml
@@ -71,12 +71,13 @@ jobs:
           AZ_MAX_STOCKFISH_TRAIN: "24000"
           AZ_STOCKFISH_POLICY_WEIGHT: "1.0"
           CONTINUE_EPOCHS: "4"
-          AZ_ARENA_GAMES: "8"
+          AZ_ARENA_GAMES: "16"
           AZ_ARENA_SEARCHES: "64"
-          AZ_ARENA_MIN_SCORE: "0.5"
-          AZ_MCTS_EVAL_POSITIONS: "48"
+          AZ_ARENA_MIN_SCORE: "0.55"
+          AZ_MCTS_EVAL_POSITIONS: "192"
           AZ_MCTS_EVAL_SEARCHES: "64"
           AZ_MIN_MCTS_ALIGNMENT_IMPROVEMENT: "0.0001"
+          AZ_MIN_MCTS_TOP_MOVE_IMPROVEMENT: "0.0"
         run: python ml/train_safe_export.py
       - name: Commit updated brain and browser model
         run: |

--- a/ml/tests/test_alpha_zero_core.py
+++ b/ml/tests/test_alpha_zero_core.py
@@ -19,6 +19,7 @@ import policy_map
 import self_play
 import stockfish_eval
 import train
+import train_fixed_eval
 
 
 class PolicyMapTests(unittest.TestCase):
@@ -135,6 +136,24 @@ class SearchAndModelTests(unittest.TestCase):
         self.assertEqual(
             train.should_accept_candidate({"loss": 0.9}, None, resumed=True),
             (False, "previous_validation_failed"),
+        )
+
+    def test_mcts_gate_rejects_top_move_accuracy_regression(self):
+        baseline = {"alignment": 0.0634, "top_move_accuracy": 0.1042}
+        candidate = {"alignment": 0.0650, "top_move_accuracy": 0.0833}
+
+        self.assertEqual(
+            train_fixed_eval.mcts_candidate_passes(baseline, candidate),
+            (False, "candidate_mcts_top_move_accuracy_regressed"),
+        )
+
+    def test_mcts_gate_requires_alignment_gain_without_accuracy_loss(self):
+        baseline = {"alignment": 0.0634, "top_move_accuracy": 0.1042}
+        candidate = {"alignment": 0.0650, "top_move_accuracy": 0.1094}
+
+        self.assertEqual(
+            train_fixed_eval.mcts_candidate_passes(baseline, candidate),
+            (True, "mcts_policy_improved"),
         )
 
     def test_batched_search_shares_model_calls_across_games(self):

--- a/ml/train_fixed_eval.py
+++ b/ml/train_fixed_eval.py
@@ -20,6 +20,7 @@ ARENA_MIN_SCORE = float(os.environ.get("AZ_ARENA_MIN_SCORE", "0.5"))
 MCTS_EVAL_POSITIONS = int(os.environ.get("AZ_MCTS_EVAL_POSITIONS", "48"))
 MCTS_EVAL_SEARCHES = int(os.environ.get("AZ_MCTS_EVAL_SEARCHES", "64"))
 MIN_MCTS_ALIGNMENT_IMPROVEMENT = float(os.environ.get("AZ_MIN_MCTS_ALIGNMENT_IMPROVEMENT", "0.0001"))
+MIN_MCTS_TOP_MOVE_IMPROVEMENT = float(os.environ.get("AZ_MIN_MCTS_TOP_MOVE_IMPROVEMENT", "0.0"))
 _EPS = 1e-7
 
 
@@ -277,6 +278,32 @@ def evaluate_mcts_alignment(model: tf.keras.Model | None, samples: list[dict], l
     return metrics
 
 
+def mcts_candidate_passes(
+    baseline_metrics: dict | None,
+    candidate_metrics: dict | None,
+) -> tuple[bool, str]:
+    if baseline_metrics is None or candidate_metrics is None:
+        return False, "candidate_mcts_evaluation_unavailable"
+
+    baseline_alignment = baseline_metrics.get("alignment")
+    candidate_alignment = candidate_metrics.get("alignment")
+    baseline_accuracy = baseline_metrics.get("top_move_accuracy")
+    candidate_accuracy = candidate_metrics.get("top_move_accuracy")
+    values = [baseline_alignment, candidate_alignment, baseline_accuracy, candidate_accuracy]
+    if any(value is None or not np.isfinite(value) for value in values):
+        return False, "candidate_mcts_metrics_unavailable"
+
+    required_alignment = baseline_alignment + MIN_MCTS_ALIGNMENT_IMPROVEMENT
+    if candidate_alignment < required_alignment:
+        return False, "candidate_mcts_alignment_did_not_improve"
+
+    required_accuracy = baseline_accuracy + MIN_MCTS_TOP_MOVE_IMPROVEMENT
+    if candidate_accuracy < required_accuracy:
+        return False, "candidate_mcts_top_move_accuracy_regressed"
+
+    return True, "mcts_policy_improved"
+
+
 def main():
     fixed_samples = load_fixed_eval_set()
     excluded_fens = {item.get("fen") for item in fixed_samples if item.get("fen")}
@@ -323,16 +350,15 @@ def main():
     if accepted and resumed:
         baseline_mcts_eval = evaluate_mcts_alignment(baseline_model, fixed_samples, "previous")
         candidate_mcts_eval = evaluate_mcts_alignment(model, fixed_samples, "candidate")
-        if baseline_mcts_eval is None or candidate_mcts_eval is None:
+        mcts_accepted, mcts_reason = mcts_candidate_passes(
+            baseline_mcts_eval,
+            candidate_mcts_eval,
+        )
+        if not mcts_accepted:
             accepted = False
-            gate_reason = "candidate_mcts_evaluation_unavailable"
+            gate_reason = mcts_reason
         else:
-            required_alignment = baseline_mcts_eval["alignment"] + MIN_MCTS_ALIGNMENT_IMPROVEMENT
-            if candidate_mcts_eval["alignment"] < required_alignment:
-                accepted = False
-                gate_reason = "candidate_mcts_alignment_did_not_improve"
-            else:
-                gate_reason = f"{gate_reason}_and_mcts_improved"
+            gate_reason = f"{gate_reason}_and_{mcts_reason}"
 
     arena_result = None
     if accepted and resumed and baseline_model is not None and ARENA_GAMES > 0:
@@ -387,6 +413,7 @@ def main():
                 "baseline_mcts_top_move_accuracy": baseline_mcts_eval["top_move_accuracy"],
                 "candidate_mcts_top_move_accuracy": candidate_mcts_eval["top_move_accuracy"],
                 "min_mcts_alignment_improvement": MIN_MCTS_ALIGNMENT_IMPROVEMENT,
+                "min_mcts_top_move_improvement": MIN_MCTS_TOP_MOVE_IMPROVEMENT,
             }
         )
 

--- a/src/ai/chessHeuristics.js
+++ b/src/ai/chessHeuristics.js
@@ -1,0 +1,214 @@
+import {
+  getPiece,
+  isKingInCheck,
+  isSquareAttacked,
+  listLegalMoves,
+  makeMove,
+} from '../rules/chessRules';
+
+const PIECE_VALUES = {
+  pawn: 100,
+  knight: 320,
+  bishop: 330,
+  rook: 500,
+  queen: 900,
+  king: 0,
+};
+
+const clamp = (value, minimum, maximum) => Math.max(minimum, Math.min(maximum, value));
+const opponent = (color) => (color === 'white' ? 'black' : 'white');
+const key = (x, y) => `${x}-${y}`;
+
+function centrality(x, y) {
+  return 7 - Math.abs(x - 3.5) - Math.abs(y - 3.5);
+}
+
+function undevelopedMinorCount(pieces, color) {
+  const row = color === 'white' ? 7 : 0;
+  return [1, 2, 5, 6].filter((column) => {
+    const piece = getPiece(pieces, row, column);
+    return piece && (piece.type === 'knight' || piece.type === 'bishop') && !piece.hasMoved;
+  }).length;
+}
+
+function piecePositionScore(pieces, piece, x, y, undeveloped) {
+  const homeRow = piece.color === 'white' ? 7 : 0;
+  const pawnRow = piece.color === 'white' ? 6 : 1;
+  const advance = Math.abs(pawnRow - x);
+
+  if (piece.type === 'pawn') {
+    let score = advance * 7;
+    if (y === 3 || y === 4) score += 12;
+    else if (y === 2 || y === 5) score += 4;
+    if ((y <= 1 || y >= 6) && undeveloped >= 2) score -= advance * 18;
+
+    const king = getPiece(pieces, homeRow, 4);
+    if (y === 5 && advance > 0 && king?.type === 'king' && !king.hasMoved) {
+      score -= advance * 28;
+    }
+    return score;
+  }
+
+  if (piece.type === 'knight') {
+    const homeSquare = x === homeRow && (y === 1 || y === 6);
+    return centrality(x, y) * 7 - (homeSquare && !piece.hasMoved ? 12 : 0);
+  }
+
+  if (piece.type === 'bishop') {
+    const homeSquare = x === homeRow && (y === 2 || y === 5);
+    return centrality(x, y) * 3 - (homeSquare && !piece.hasMoved ? 8 : 0);
+  }
+
+  if (piece.type === 'rook') {
+    return centrality(x, y) * 0.5;
+  }
+
+  if (piece.type === 'queen') {
+    return centrality(x, y) - (piece.hasMoved && undeveloped >= 3 ? 18 : 0);
+  }
+
+  if (piece.type === 'king') {
+    if (x === homeRow && (y === 2 || y === 6)) return 38;
+    if (piece.hasMoved && (x !== homeRow || y !== 4)) return -24;
+  }
+
+  return 0;
+}
+
+function positionScoreCp(pieces, color) {
+  const undeveloped = {
+    white: undevelopedMinorCount(pieces, 'white'),
+    black: undevelopedMinorCount(pieces, 'black'),
+  };
+  const bishops = { white: 0, black: 0 };
+  let whiteScore = 0;
+
+  for (let x = 0; x < 8; x += 1) {
+    for (let y = 0; y < 8; y += 1) {
+      const piece = getPiece(pieces, x, y);
+      if (!piece) continue;
+      const sign = piece.color === 'white' ? 1 : -1;
+      whiteScore += sign * (
+        PIECE_VALUES[piece.type] +
+        piecePositionScore(pieces, piece, x, y, undeveloped[piece.color])
+      );
+      if (piece.type === 'bishop') bishops[piece.color] += 1;
+    }
+  }
+
+  if (bishops.white >= 2) whiteScore += 18;
+  if (bishops.black >= 2) whiteScore -= 18;
+  if (isKingInCheck(pieces, 'white')) whiteScore -= 45;
+  if (isKingInCheck(pieces, 'black')) whiteScore += 45;
+
+  return color === 'white' ? whiteScore : -whiteScore;
+}
+
+export function evaluatePosition(pieces, color) {
+  return Math.tanh(positionScoreCp(pieces, color) / 650);
+}
+
+export function scoreMove(pieces, move, color, enPassantTarget = null) {
+  const promotion = move.promotionType || (move.needsPromotion ? 'queen' : null);
+  const { pieces: after, nextEnPassant } = makeMove(
+    pieces,
+    move.from,
+    move.to,
+    promotion,
+    enPassantTarget,
+  );
+  const enemy = opponent(color);
+  const givesCheck = isKingInCheck(after, enemy);
+  if (givesCheck && listLegalMoves(after, enemy, nextEnPassant).length === 0) return 1;
+
+  let scoreCp = positionScoreCp(after, color);
+  const movedPiece = getPiece(after, move.to.x, move.to.y);
+  if (movedPiece && isSquareAttacked(after, move.to.x, move.to.y, enemy)) {
+    const withoutMovedPiece = { ...after };
+    delete withoutMovedPiece[key(move.to.x, move.to.y)];
+    const defended = isSquareAttacked(
+      withoutMovedPiece,
+      move.to.x,
+      move.to.y,
+      color,
+    );
+    scoreCp -= PIECE_VALUES[movedPiece.type] * (defended ? 0.08 : 0.55);
+  }
+  if (givesCheck) scoreCp += 24;
+
+  return Math.tanh(scoreCp / 650);
+}
+
+function stableSoftmax(values) {
+  const max = Math.max(...values);
+  const exponentials = values.map((value) => Math.exp(value - max));
+  const total = exponentials.reduce((sum, value) => sum + value, 0);
+  if (!Number.isFinite(total) || total <= 0) {
+    return values.map(() => 1 / Math.max(1, values.length));
+  }
+  return exponentials.map((value) => value / total);
+}
+
+export function stabilizePolicyValue(
+  pieces,
+  color,
+  enPassantTarget,
+  prediction,
+  { neuralValueWeight = 0.55, neuralPolicyWeight = 0.55 } = {},
+) {
+  const legalMoves = prediction?.legalMoves || listLegalMoves(pieces, color, enPassantTarget);
+  if (legalMoves.length === 0) {
+    return {
+      value: isKingInCheck(pieces, color) ? -1 : 0,
+      legalMoves,
+      priors: new Map(),
+      moveScores: new Map(),
+    };
+  }
+
+  const moveScores = new Map();
+  const heuristicScores = legalMoves.map((move) => {
+    const score = scoreMove(pieces, move, color, enPassantTarget);
+    moveScores.set(`${move.from.x}-${move.from.y}:${move.to.x}-${move.to.y}:${move.promotionType || ''}`, score);
+    return score * 8;
+  });
+  const heuristicPriors = stableSoftmax(heuristicScores);
+  const neuralAvailable = prediction?.neuralAvailable !== false;
+  const neuralTotal = legalMoves.reduce((sum, move) => {
+    const probability = Number(prediction?.priors?.get(
+      `${move.from.x}-${move.from.y}:${move.to.x}-${move.to.y}:${move.promotionType || ''}`,
+    ));
+    return sum + (Number.isFinite(probability) && probability > 0 ? probability : 0);
+  }, 0);
+  const policyWeight = neuralAvailable && neuralTotal > 0
+    ? clamp(neuralPolicyWeight, 0, 1)
+    : 0;
+  const priors = new Map();
+
+  legalMoves.forEach((move, index) => {
+    const moveId = `${move.from.x}-${move.from.y}:${move.to.x}-${move.to.y}:${move.promotionType || ''}`;
+    const rawNeuralPrior = Number(prediction?.priors?.get(moveId)) || 0;
+    const neuralPrior = rawNeuralPrior > 0 ? rawNeuralPrior / neuralTotal : 0;
+    priors.set(
+      moveId,
+      policyWeight * neuralPrior + (1 - policyWeight) * heuristicPriors[index],
+    );
+  });
+
+  const staticValue = evaluatePosition(pieces, color);
+  const valueWeight = neuralAvailable ? clamp(neuralValueWeight, 0, 1) : 0;
+  const neuralValue = Number.isFinite(prediction?.value) ? prediction.value : 0;
+  const value = clamp(valueWeight * neuralValue + (1 - valueWeight) * staticValue, -1, 1);
+
+  return { ...prediction, value, legalMoves, priors, moveScores };
+}
+
+export function rankMoves(prediction) {
+  return [...prediction.legalMoves].sort((first, second) => {
+    const firstId = `${first.from.x}-${first.from.y}:${first.to.x}-${first.to.y}:${first.promotionType || ''}`;
+    const secondId = `${second.from.x}-${second.from.y}:${second.to.x}-${second.to.y}:${second.promotionType || ''}`;
+    const firstScore = (prediction.priors.get(firstId) || 0) + 0.35 * (prediction.moveScores.get(firstId) || 0);
+    const secondScore = (prediction.priors.get(secondId) || 0) + 0.35 * (prediction.moveScores.get(secondId) || 0);
+    return secondScore - firstScore;
+  });
+}

--- a/src/ai/mctsAI.js
+++ b/src/ai/mctsAI.js
@@ -4,6 +4,7 @@ import {
   predictPolicyValueBatchForPositions,
   predictPolicyValueForMoves,
 } from './nnAI';
+import { stabilizePolicyValue } from './chessHeuristics';
 
 const DEFAULT_CPUCT = 1.5;
 
@@ -28,6 +29,7 @@ function uniformPrediction(pieces, color, enPassantTarget) {
     value: 0,
     legalMoves,
     priors: new Map(legalMoves.map((move) => [moveKey(move), probability])),
+    neuralAvailable: false,
   };
 }
 
@@ -126,11 +128,13 @@ async function evaluateAndExpand(node) {
     console.warn('Neural MCTS inference failed; using uniform priors.', error);
   }
 
-  const { value, priors, legalMoves } = prediction || uniformPrediction(
+  const stabilized = stabilizePolicyValue(
     node.pieces,
     node.toMove,
     node.enPassantTarget,
+    prediction || uniformPrediction(node.pieces, node.toMove, node.enPassantTarget),
   );
+  const { value, priors, legalMoves } = stabilized;
   node.expand(legalMoves, priors);
   return Number.isFinite(value) ? value : 0;
 }
@@ -171,10 +175,15 @@ async function evaluateAndExpandBatch(nodes) {
   }
 
   pending.forEach(({ node, index }, predictionIndex) => {
-    const prediction = predictions[predictionIndex] || uniformPrediction(
+    const prediction = stabilizePolicyValue(
       node.pieces,
       node.toMove,
       node.enPassantTarget,
+      predictions[predictionIndex] || uniformPrediction(
+        node.pieces,
+        node.toMove,
+        node.enPassantTarget,
+      ),
     );
     node.expand(prediction.legalMoves, prediction.priors);
     values[index] = Number.isFinite(prediction.value) ? prediction.value : 0;

--- a/src/ai/mctsAI.test.js
+++ b/src/ai/mctsAI.test.js
@@ -1,4 +1,4 @@
-import { listLegalMoves } from '../rules/chessRules';
+import { listLegalMoves, makeMove } from '../rules/chessRules';
 
 jest.mock('./nnAI', () => ({
   moveKey: (move) => `${move.from.x}-${move.from.y}:${move.to.x}-${move.to.y}:${move.promotionType || ''}`,
@@ -14,6 +14,18 @@ import {
 import { pickMCTSMove } from './mctsAI';
 
 const piece = (color, type, hasMoved = false) => ({ color, type, hasMoved });
+
+function initialPieces() {
+  const pieces = {};
+  const backRank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook'];
+  backRank.forEach((type, column) => {
+    pieces[`0-${column}`] = piece('black', type);
+    pieces[`1-${column}`] = piece('black', 'pawn');
+    pieces[`6-${column}`] = piece('white', 'pawn');
+    pieces[`7-${column}`] = piece('white', type);
+  });
+  return pieces;
+}
 
 describe('neural PUCT MCTS', () => {
   beforeEach(() => {
@@ -81,5 +93,19 @@ describe('neural PUCT MCTS', () => {
     expect(chosen.from).toEqual({ x: 2, y: 1 });
     expect(chosen.to).toEqual({ x: 1, y: 1 });
     expect(predictPolicyValueBatchForPositions).not.toHaveBeenCalled();
+  });
+
+  test('does not repeat the live early f-pawn regression', async () => {
+    let state = makeMove(initialPieces(), { x: 6, y: 4 }, { x: 4, y: 4 });
+    state = makeMove(state.pieces, { x: 1, y: 2 }, { x: 2, y: 2 }, null, state.nextEnPassant);
+    state = makeMove(state.pieces, { x: 6, y: 3 }, { x: 4, y: 3 }, null, state.nextEnPassant);
+
+    const chosen = await pickMCTSMove(state.pieces, 'black', state.nextEnPassant, {
+      timeMs: 1000,
+      maxIterations: 96,
+      batchSize: 8,
+    });
+
+    expect(chosen).not.toMatchObject({ from: { x: 1, y: 5 }, to: { x: 2, y: 5 } });
   });
 });

--- a/src/ai/nnAI.js
+++ b/src/ai/nnAI.js
@@ -1,5 +1,6 @@
 import * as tf from '@tensorflow/tfjs';
 import { listLegalMoves, makeMove, getPiece, isKingInCheck } from '../rules/chessRules';
+import { rankMoves, stabilizePolicyValue } from './chessHeuristics';
 
 export const POLICY_CHANNELS = 5;
 export const POLICY_SIZE = 64 * 64 * POLICY_CHANNELS;
@@ -124,25 +125,11 @@ async function rawPredictions(model, positions) {
   }
 }
 
-async function rawPrediction(model, pieces, isWhiteTurn, enPassantTarget) {
-  const predictions = await rawPredictions(model, [{
-    pieces,
-    color: isWhiteTurn ? 'white' : 'black',
-    enPassantTarget,
-  }]);
-  return predictions[0];
-}
-
-async function evalPosition(model, pieces, isWhiteTurn, enPassantTarget) {
-  const { value } = await rawPrediction(model, pieces, isWhiteTurn, enPassantTarget);
-  return value;
-}
-
 function uniformPrediction(legalMoves) {
   const uniform = 1 / Math.max(1, legalMoves.length);
   const priors = new Map();
   legalMoves.forEach((move) => priors.set(moveKey(move), uniform));
-  return { value: 0, priors, legalMoves };
+  return { value: 0, priors, legalMoves, neuralAvailable: false };
 }
 
 function predictionForLegalMoves(legalMoves, raw) {
@@ -151,7 +138,7 @@ function predictionForLegalMoves(legalMoves, raw) {
   const probabilities = stableSoftmax(logits);
   const priors = new Map();
   legalMoves.forEach((move, index) => priors.set(moveKey(move), probabilities[index]));
-  return { value: raw.value, priors, legalMoves };
+  return { value: raw.value, priors, legalMoves, neuralAvailable: true };
 }
 
 export async function predictPolicyValueBatchForPositions(positions) {
@@ -194,56 +181,97 @@ export async function predictPolicyValueForMoves(pieces, color, enPassantTarget)
   return prediction;
 }
 
-export async function pickNNMove(pieces, color, enPassantTarget, depth = 2) {
-  const moves = listLegalMoves(pieces, color, enPassantTarget);
-  let bestMove = null;
-  let bestScore = -Infinity;
-
-  for (const move of moves) {
-    const promotion = move.promotionType || (move.needsPromotion ? 'queen' : null);
-    const { pieces: after, nextEnPassant } = makeMove(
-      pieces,
-      move.from,
-      move.to,
-      promotion,
-      enPassantTarget,
-    );
-    const nextColor = color === 'white' ? 'black' : 'white';
-    const score = -(await negamax(after, depth - 1, nextColor, nextEnPassant));
-    if (score > bestScore) {
-      bestScore = score;
-      bestMove = { ...move, promotionType: promotion };
-    }
-  }
-
-  return bestMove;
+function applyMove(pieces, move, enPassantTarget) {
+  const promotion = move.promotionType || (move.needsPromotion ? 'queen' : null);
+  const result = makeMove(pieces, move.from, move.to, promotion, enPassantTarget);
+  return {
+    ...result,
+    move: { ...move, promotionType: promotion },
+  };
 }
 
-async function negamax(pieces, depth, color, enPassantTarget) {
-  const moves = listLegalMoves(pieces, color, enPassantTarget);
-  if (moves.length === 0) return isKingInCheck(pieces, color) ? -1 : 0;
-
-  if (depth === 0) {
-    try {
-      const model = await loadModel();
-      return await evalPosition(model, pieces, color === 'white', enPassantTarget);
-    } catch (error) {
-      return 0;
-    }
-  }
+export async function pickNNMove(
+  pieces,
+  color,
+  enPassantTarget,
+  depth = 2,
+  {
+    predictBatch = predictPolicyValueBatchForPositions,
+    rootMoveLimit = 12,
+    replyLimit = 10,
+  } = {},
+) {
+  const [rawRoot] = await predictBatch([{ pieces, color, enPassantTarget }]);
+  const rootPrediction = stabilizePolicyValue(
+    pieces,
+    color,
+    enPassantTarget,
+    rawRoot,
+  );
+  const rootMoves = rankMoves(rootPrediction).slice(0, Math.max(1, rootMoveLimit));
+  if (rootMoves.length === 0) return null;
+  if (depth <= 1) return applyMove(pieces, rootMoves[0], enPassantTarget).move;
 
   const nextColor = color === 'white' ? 'black' : 'white';
-  let best = -Infinity;
-  for (const move of moves) {
-    const promotion = move.promotionType || (move.needsPromotion ? 'queen' : null);
-    const { pieces: after, nextEnPassant } = makeMove(
-      pieces,
-      move.from,
-      move.to,
-      promotion,
-      enPassantTarget,
+  const candidates = rootMoves.map((move) => ({
+    ...applyMove(pieces, move, enPassantTarget),
+    score: Infinity,
+  }));
+  const rawReplies = await predictBatch(candidates.map((candidate) => ({
+    pieces: candidate.pieces,
+    color: nextColor,
+    enPassantTarget: candidate.nextEnPassant,
+  })));
+  const leaves = [];
+
+  candidates.forEach((candidate, candidateIndex) => {
+    const replyPrediction = stabilizePolicyValue(
+      candidate.pieces,
+      nextColor,
+      candidate.nextEnPassant,
+      rawReplies[candidateIndex],
     );
-    best = Math.max(best, -(await negamax(after, depth - 1, nextColor, nextEnPassant)));
+    if (replyPrediction.legalMoves.length === 0) {
+      candidate.score = isKingInCheck(candidate.pieces, nextColor) ? 1 : 0;
+      return;
+    }
+
+    const replies = rankMoves(replyPrediction).slice(0, Math.max(1, replyLimit));
+    replies.forEach((reply) => {
+      const afterReply = applyMove(candidate.pieces, reply, candidate.nextEnPassant);
+      leaves.push({
+        candidateIndex,
+        pieces: afterReply.pieces,
+        color,
+        enPassantTarget: afterReply.nextEnPassant,
+      });
+    });
+  });
+
+  if (leaves.length > 0) {
+    const rawLeaves = await predictBatch(leaves);
+    leaves.forEach((leaf, leafIndex) => {
+      const leafPrediction = stabilizePolicyValue(
+        leaf.pieces,
+        leaf.color,
+        leaf.enPassantTarget,
+        rawLeaves[leafIndex],
+      );
+      candidates[leaf.candidateIndex].score = Math.min(
+        candidates[leaf.candidateIndex].score,
+        leafPrediction.value,
+      );
+    });
   }
-  return best;
+
+  const best = candidates.reduce((current, candidate) => {
+    const moveId = moveKey(candidate.move);
+    const priorBonus = 0.1 * (rootPrediction.priors.get(moveId) || 0);
+    const positionalBonus = 0.04 * (rootPrediction.moveScores.get(moveId) || 0);
+    const score = candidate.score + priorBonus + positionalBonus;
+    if (!current || score > current.score) return { candidate, score };
+    return current;
+  }, null);
+
+  return best?.candidate.move || null;
 }

--- a/src/ai/nnAI.test.js
+++ b/src/ai/nnAI.test.js
@@ -1,4 +1,24 @@
-import { moveToPolicyIndex, POLICY_SIZE } from './nnAI';
+import { listLegalMoves, makeMove } from '../rules/chessRules';
+import { scoreMove } from './chessHeuristics';
+import { moveKey, moveToPolicyIndex, pickNNMove, POLICY_SIZE } from './nnAI';
+
+const piece = (color, type, hasMoved = false) => ({ color, type, hasMoved });
+
+function initialPieces() {
+  const pieces = {};
+  const backRank = ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook'];
+  backRank.forEach((type, column) => {
+    pieces[`0-${column}`] = piece('black', type);
+    pieces[`1-${column}`] = piece('black', 'pawn');
+    pieces[`6-${column}`] = piece('white', 'pawn');
+    pieces[`7-${column}`] = piece('white', type);
+  });
+  return pieces;
+}
+
+function play(pieces, from, to, enPassantTarget = null) {
+  return makeMove(pieces, from, to, null, enPassantTarget);
+}
 
 describe('neural policy encoding', () => {
   test('promotion choices have distinct policy indices', () => {
@@ -22,5 +42,62 @@ describe('neural policy encoding', () => {
       to: { x: 4, y: 4 },
     };
     expect(moveToPolicyIndex(move, 4096)).toBe(12 * 64 + 28);
+  });
+
+  test('opening guard prefers development over weakening flank pawns', () => {
+    const state = play(initialPieces(), { x: 6, y: 4 }, { x: 4, y: 4 });
+    const moves = listLegalMoves(state.pieces, 'black', state.nextEnPassant);
+    const findMove = (from, to) => moves.find((move) => (
+      move.from.x === from.x && move.from.y === from.y &&
+      move.to.x === to.x && move.to.y === to.y
+    ));
+    const knight = findMove({ x: 0, y: 6 }, { x: 2, y: 5 });
+    const bPawn = findMove({ x: 1, y: 1 }, { x: 3, y: 1 });
+    const fPawn = findMove({ x: 1, y: 5 }, { x: 2, y: 5 });
+
+    expect(scoreMove(state.pieces, knight, 'black', state.nextEnPassant)).toBeGreaterThan(
+      scoreMove(state.pieces, bPawn, 'black', state.nextEnPassant),
+    );
+    expect(scoreMove(state.pieces, knight, 'black', state.nextEnPassant)).toBeGreaterThan(
+      scoreMove(state.pieces, fPawn, 'black', state.nextEnPassant),
+    );
+  });
+
+  test('batches reply evaluation and rejects the live b-pawn regression', async () => {
+    let state = play(initialPieces(), { x: 6, y: 4 }, { x: 4, y: 4 });
+    state = play(state.pieces, { x: 0, y: 6 }, { x: 2, y: 5 }, state.nextEnPassant);
+    state = play(state.pieces, { x: 6, y: 3 }, { x: 4, y: 3 }, state.nextEnPassant);
+
+    const predictBatch = jest.fn(async (positions) => positions.map((position) => {
+      const legalMoves = listLegalMoves(
+        position.pieces,
+        position.color,
+        position.enPassantTarget,
+      );
+      const probability = 1 / Math.max(1, legalMoves.length);
+      const priors = new Map(legalMoves.map((move) => [moveKey(move), probability]));
+      const badMove = legalMoves.find((move) => (
+        move.from.x === 1 && move.from.y === 1 && move.to.x === 3 && move.to.y === 1
+      ));
+      if (badMove) priors.set(moveKey(badMove), 0.9);
+      return {
+        value: 0,
+        legalMoves,
+        priors,
+        neuralAvailable: true,
+      };
+    }));
+
+    const chosen = await pickNNMove(
+      state.pieces,
+      'black',
+      state.nextEnPassant,
+      2,
+      { predictBatch },
+    );
+
+    expect(chosen).not.toMatchObject({ from: { x: 1, y: 1 }, to: { x: 3, y: 1 } });
+    expect(predictBatch).toHaveBeenCalledTimes(3);
+    expect(predictBatch.mock.calls.some(([positions]) => positions.length > 1)).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

- Live Neural MCTS replied `1 e4 c6 2 d4 f6 3 Nc3 b5`
- Live NN replied `1 e4 Nf6 2 d4 b5` and its second reply took about 15 seconds
- The deployed `gh-pages` model hash matches `master`, so this is a search and model-quality issue rather than a stale deployment
- The latest promoted model improved MCTS alignment from `0.06348` to `0.06503` while Stockfish top-move accuracy fell from `10.42%` to `8.33%`
- Eight arena draws still produced the old passing score of `0.500`

## Changes

- Add a shared material, development, king-safety, hanging-piece, and mate guard for both browser AI modes
- Blend tactical priors and values with the neural outputs so weak model guesses cannot freely hang pieces or weaken the king
- Replace sequential NN leaf evaluation with three batched inference passes that use both the policy and value heads
- Add regression coverage for the observed `...f6` and `...b5` failures, including a network that assigns `...b5` a `0.9` prior
- Reject candidates when Stockfish top-move accuracy regresses even if the softer alignment metric rises
- Expand MCTS promotion evaluation from 48 to 192 positions
- Expand the arena from 8 to 16 games and require a score of at least `0.55` so all draws no longer prove improvement

## Validation

- 9 browser tests pass
- Optimized production build passes
- The promotion gate rejects the exact latest regression metrics
- Published branch tree matches the reviewed local tree