### PR TITLE
Load the chess website and neural AI faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
           name: browser-test-log
           path: browser-test.log
           if-no-files-found: warn
+      - name: Optimize browser neural model
+        run: python3 scripts/quantize_tfjs_model.py public/nn/model.json
       - name: Build production site
         run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Optimize browser neural model
+        run: python3 scripts/quantize_tfjs_model.py public/nn/model.json
+
       - name: Build
         run: npm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+__pycache__/
+*.py[cod]
 
 # production
 /build

--- a/ml/tests/test_quantize_tfjs_model.py
+++ b/ml/tests/test_quantize_tfjs_model.py
@@ -1,0 +1,65 @@
+import json
+import pathlib
+import struct
+import sys
+import tempfile
+import unittest
+
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT_DIR / "scripts"))
+
+from quantize_tfjs_model import quantize_model
+
+
+class QuantizeTFJSModelTests(unittest.TestCase):
+    def test_quantizes_float32_weights_and_removes_stale_shards(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = pathlib.Path(tmp)
+            model_path = model_dir / "model.json"
+            shard_path = model_dir / "group1-shard1of1.bin"
+            stale_path = model_dir / "group1-shard1of2.bin"
+            model_path.write_text(json.dumps({
+                "weightsManifest": [{
+                    "paths": [shard_path.name],
+                    "weights": [
+                        {"name": "dense/kernel", "shape": [2], "dtype": "float32"},
+                        {"name": "dense/bias", "shape": [1], "dtype": "float32"},
+                    ],
+                }],
+            }), encoding="utf-8")
+            shard_path.write_bytes(struct.pack("<fff", 0.25, -1.5, 3.125))
+            stale_path.write_bytes(b"stale")
+
+            sizes = quantize_model(model_path)
+            updated = json.loads(model_path.read_text(encoding="utf-8"))
+            weights = updated["weightsManifest"][0]["weights"]
+
+            self.assertEqual((12, 6), sizes)
+            self.assertEqual((0.25, -1.5, 3.125), struct.unpack("<eee", shard_path.read_bytes()))
+            self.assertTrue(
+                all(weight["quantization"] == {"dtype": "float16"} for weight in weights)
+            )
+            self.assertFalse(stale_path.exists())
+            self.assertEqual((6, 6), quantize_model(model_path))
+
+    def test_rejects_a_truncated_weight_shard(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_dir = pathlib.Path(tmp)
+            model_path = model_dir / "model.json"
+            model_path.write_text(json.dumps({
+                "weightsManifest": [{
+                    "paths": ["group1-shard1of1.bin"],
+                    "weights": [
+                        {"name": "dense/kernel", "shape": [2], "dtype": "float32"},
+                    ],
+                }],
+            }), encoding="utf-8")
+            (model_dir / "group1-shard1of1.bin").write_bytes(struct.pack("<f", 0.25))
+
+            with self.assertRaisesRegex(ValueError, "has 4 bytes, expected 8"):
+                quantize_model(model_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ml/tests/test_tfjs_layers_export.py
+++ b/ml/tests/test_tfjs_layers_export.py
@@ -1,0 +1,45 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+import numpy as np
+import tensorflow as tf
+
+
+ML_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ML_DIR))
+
+from tfjs_layers_export import WEIGHTS_FILENAME, export_keras_layers_model
+
+
+class TFJSLayersExportTests(unittest.TestCase):
+    def test_float16_export_removes_stale_shards(self):
+        model = tf.keras.Sequential([
+            tf.keras.Input(shape=(2,)),
+            tf.keras.layers.Dense(2),
+        ])
+        model(np.zeros((1, 2), dtype=np.float32))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out_dir = pathlib.Path(tmp)
+            (out_dir / "group1-shard1of3.bin").write_bytes(b"stale")
+
+            model_json_path = export_keras_layers_model(model, out_dir)
+            model_json = json.loads(model_json_path.read_text(encoding="utf-8"))
+            weights = model_json["weightsManifest"][0]["weights"]
+
+            self.assertEqual([WEIGHTS_FILENAME], model_json["weightsManifest"][0]["paths"])
+            self.assertTrue(all(weight["dtype"] == "float32" for weight in weights))
+            self.assertTrue(
+                all(weight["quantization"] == {"dtype": "float16"} for weight in weights)
+            )
+            self.assertFalse((out_dir / "group1-shard1of3.bin").exists())
+
+            scalar_count = sum(np.prod(weight["shape"]) for weight in weights)
+            self.assertEqual(2 * scalar_count, (out_dir / WEIGHTS_FILENAME).stat().st_size)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ml/tfjs_layers_export.py
+++ b/ml/tfjs_layers_export.py
@@ -28,16 +28,16 @@ def weight_name(layer: tf.keras.layers.Layer, weight) -> str:
     return name
 
 
-def float32_bytes(array: np.ndarray) -> bytes:
-    array = np.asarray(array)
-    if array.dtype != np.float32:
-        array = array.astype(np.float32)
-    return np.ascontiguousarray(array).tobytes(order="C")
+def float16_bytes(array: np.ndarray) -> bytes:
+    return np.ascontiguousarray(array, dtype="<f2").tobytes(order="C")
 
 
 def export_keras_layers_model(model: tf.keras.Model, out_dir: pathlib.Path) -> pathlib.Path:
-    """Write a TFJS Layers model.json and one weight shard for model."""
+    """Write a float16-quantized TFJS Layers model and one weight shard"""
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    for stale_shard in out_dir.glob("group*.bin"):
+        stale_shard.unlink()
 
     weights_manifest = []
     weight_chunks = []
@@ -50,8 +50,9 @@ def export_keras_layers_model(model: tf.keras.Model, out_dir: pathlib.Path) -> p
                 "name": weight_name(layer, weight),
                 "shape": list(array.shape),
                 "dtype": "float32",
+                "quantization": {"dtype": "float16"},
             })
-            weight_chunks.append(float32_bytes(array))
+            weight_chunks.append(float16_bytes(array))
 
     (out_dir / WEIGHTS_FILENAME).write_bytes(b"".join(weight_chunks))
 

--- a/scripts/quantize_tfjs_model.py
+++ b/scripts/quantize_tfjs_model.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import math
+import os
+import pathlib
+import struct
+
+
+def _scalar_count(weights: list[dict]) -> int:
+    return sum(math.prod(weight["shape"]) for weight in weights)
+
+
+def _write_atomic(path: pathlib.Path, data: bytes | str) -> None:
+    temporary = path.with_name(f".{path.name}.tmp")
+    if isinstance(data, str):
+        temporary.write_text(data, encoding="utf-8")
+    else:
+        temporary.write_bytes(data)
+    os.replace(temporary, path)
+
+
+def quantize_model(model_path: pathlib.Path) -> tuple[int, int]:
+    model = json.loads(model_path.read_text(encoding="utf-8"))
+    model_dir = model_path.parent
+    original_bytes = 0
+    quantized_bytes = 0
+    referenced_paths = set()
+
+    for group in model.get("weightsManifest", []):
+        paths = group.get("paths", [])
+        weights = group.get("weights", [])
+        if len(paths) != 1:
+            raise ValueError("float16 optimizer requires one shard per weight group")
+
+        shard_path = model_dir / paths[0]
+        referenced_paths.add(shard_path.resolve())
+        scalar_count = _scalar_count(weights)
+        existing_quantization = {
+            weight.get("quantization", {}).get("dtype") for weight in weights
+        }
+
+        if existing_quantization == {"float16"}:
+            expected_size = scalar_count * 2
+            actual_size = shard_path.stat().st_size
+            if actual_size != expected_size:
+                raise ValueError(
+                    f"{shard_path.name} has {actual_size} bytes, expected {expected_size}"
+                )
+            original_bytes += actual_size
+            quantized_bytes += actual_size
+            continue
+
+        if existing_quantization != {None}:
+            raise ValueError(f"unsupported mixed quantization in {shard_path.name}")
+        if any(weight.get("dtype") != "float32" for weight in weights):
+            raise ValueError(f"unsupported weight dtype in {shard_path.name}")
+
+        source = shard_path.read_bytes()
+        expected_size = scalar_count * 4
+        if len(source) != expected_size:
+            raise ValueError(
+                f"{shard_path.name} has {len(source)} bytes, expected {expected_size}"
+            )
+
+        output = bytearray(scalar_count * 2)
+        for index, (value,) in enumerate(struct.iter_unpack("<f", source)):
+            struct.pack_into("<e", output, index * 2, value)
+        _write_atomic(shard_path, bytes(output))
+
+        for weight in weights:
+            weight["quantization"] = {"dtype": "float16"}
+        original_bytes += len(source)
+        quantized_bytes += len(output)
+
+    _write_atomic(model_path, json.dumps(model))
+
+    for shard_path in model_dir.glob("group*.bin"):
+        if shard_path.resolve() not in referenced_paths:
+            shard_path.unlink()
+
+    return original_bytes, quantized_bytes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Quantize TFJS float32 weights to float16")
+    parser.add_argument("model_json", type=pathlib.Path)
+    args = parser.parse_args()
+    original_bytes, quantized_bytes = quantize_model(args.model_json)
+    print(f"optimized TFJS weights: {original_bytes} -> {quantized_bytes} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ChessBoard.js
+++ b/src/ChessBoard.js
@@ -12,8 +12,44 @@ import {
   hasAnyLegalMove,
 } from "./chessRules";
 import { pickRandomMove } from "./randomAI";
-import { pickMCTSMove } from "./mctsAI";
-import { pickNNMove } from "./nnAI";
+
+let mctsModulePromise = null;
+let nnModulePromise = null;
+
+function loadMCTSModule() {
+  if (!mctsModulePromise) {
+    mctsModulePromise = import("./ai/mctsAI").catch((error) => {
+      mctsModulePromise = null;
+      throw error;
+    });
+  }
+  return mctsModulePromise;
+}
+
+function loadNNModule() {
+  if (!nnModulePromise) {
+    nnModulePromise = import("./ai/nnAI").catch((error) => {
+      nnModulePromise = null;
+      throw error;
+    });
+  }
+  return nnModulePromise;
+}
+
+function preloadAIMode(mode, warmModel = false) {
+  let preload = null;
+  if (mode === "mcts") {
+    preload = warmModel
+      ? Promise.all([loadMCTSModule(), loadNNModule()]).then(([, nn]) => nn.warmNNModel())
+      : loadMCTSModule();
+  } else if (mode === "nn") {
+    preload = warmModel ? loadNNModule().then((nn) => nn.warmNNModel()) : loadNNModule();
+  }
+
+  preload?.catch((error) => {
+    console.warn("AI preload failed", error);
+  });
+}
 
 const initPiece = (color, type) => ({ color, type, hasMoved: false });
 
@@ -448,19 +484,25 @@ export default function ChessBoard() {
     setIsThinking(true);
 
     let aiMove = null;
-    if (mode === "random") {
-      aiMove = await pickRandomMove(pieces, color, enPassantTarget);
-    } else if (mode === "mcts") {
-      aiMove = await pickMCTSMove(pieces, color, enPassantTarget, {
-        timeMs: 2000,
-        maxIterations: 4096,
-        batchSize: 16,
-      });
-    } else if (mode === "nn") {
-      aiMove = await pickNNMove(pieces, color, enPassantTarget);
+    try {
+      if (mode === "random") {
+        aiMove = await pickRandomMove(pieces, color, enPassantTarget);
+      } else if (mode === "mcts") {
+        const { pickMCTSMove } = await loadMCTSModule();
+        aiMove = await pickMCTSMove(pieces, color, enPassantTarget, {
+          timeMs: 2000,
+          maxIterations: 4096,
+          batchSize: 16,
+        });
+      } else if (mode === "nn") {
+        const { pickNNMove } = await loadNNModule();
+        aiMove = await pickNNMove(pieces, color, enPassantTarget);
+      }
+    } catch (error) {
+      console.warn("AI move failed", error);
+    } finally {
+      setIsThinking(false);
     }
-
-    setIsThinking(false);
     if (!aiMove) return;
 
     // snapshot for undo BEFORE AI move
@@ -570,7 +612,12 @@ export default function ChessBoard() {
                 <button
                   key={m.key}
                   className={`seg-btn ${whiteMode === m.key ? "is-active" : ""}`}
-                  onClick={() => setWhiteMode(m.key)}
+                  onPointerEnter={() => preloadAIMode(m.key)}
+                  onFocus={() => preloadAIMode(m.key)}
+                  onClick={() => {
+                    preloadAIMode(m.key, true);
+                    setWhiteMode(m.key);
+                  }}
                   disabled={isThinking || frozenForPromotion}
                   type="button"
                 >
@@ -589,7 +636,12 @@ export default function ChessBoard() {
                 <button
                   key={m.key}
                   className={`seg-btn ${blackMode === m.key ? "is-active" : ""}`}
-                  onClick={() => setBlackMode(m.key)}
+                  onPointerEnter={() => preloadAIMode(m.key)}
+                  onFocus={() => preloadAIMode(m.key)}
+                  onClick={() => {
+                    preloadAIMode(m.key, true);
+                    setBlackMode(m.key);
+                  }}
                   disabled={isThinking || frozenForPromotion}
                   type="button"
                 >

--- a/src/ai/nnAI.js
+++ b/src/ai/nnAI.js
@@ -7,6 +7,7 @@ export const POLICY_SIZE = 64 * 64 * POLICY_CHANNELS;
 const LEGACY_POLICY_SIZE = 64 * 64;
 
 let modelPromise = null;
+let modelWarmPromise = null;
 
 async function loadModel() {
   if (!modelPromise) {
@@ -16,6 +17,28 @@ async function loadModel() {
     });
   }
   return modelPromise;
+}
+
+export async function warmNNModel() {
+  if (!modelWarmPromise) {
+    modelWarmPromise = loadModel().then(async (model) => {
+      const planeCount = Number(model.inputs?.[0]?.shape?.[3]) || 18;
+      const input = tf.zeros([1, 8, 8, planeCount]);
+      const prediction = model.predict(input);
+      const outputs = Array.isArray(prediction) ? prediction : [prediction];
+
+      try {
+        await Promise.all(outputs.map((output) => output.data()));
+      } finally {
+        tf.dispose([input, ...outputs]);
+      }
+      return model;
+    }).catch((error) => {
+      modelWarmPromise = null;
+      throw error;
+    });
+  }
+  return modelWarmPromise;
 }
 
 function boardCoordToSquare(pos) {
@@ -161,7 +184,7 @@ export async function predictPolicyValueBatchForPositions(positions) {
   if (pending.length === 0) return results;
 
   try {
-    const model = await loadModel();
+    const model = await warmNNModel();
     const predictions = await rawPredictions(model, pending);
     pending.forEach((position, pendingIndex) => {
       results[position.index] = predictionForLegalMoves(position.legalMoves, predictions[pendingIndex]);


### PR DESCRIPTION
## Why

- The live page ships TensorFlow.js in the initial bundle even when both players are human
- The first Neural MCTS or NN turn then downloads a 25,439,236-byte float32 model
- First inference also pays WebGL shader compilation cost

## Changes

- Lazy-load Neural MCTS, NN, and TensorFlow.js only when a neural mode is requested
- Start loading the relevant code on hover or keyboard focus
- Start model download and a zero-input warm-up as soon as a neural mode is selected
- Keep the UI from getting stuck if a lazy chunk fails to load
- Quantize deployed TFJS weights to the supported float16 wire format before every build
- Export future accepted nightly models directly as float16
- Remove stale unreferenced weight shards from deployment and future exports
- Add corruption, idempotency, quantization metadata, and stale-shard tests

## Measured results

- Initial JavaScript gzip size drops from 296.92 kB to 67.04 kB, a 77% reduction
- TensorFlow.js moves to a 227.53 kB on-demand chunk
- Browser model transfer drops from 25,439,236 to 12,719,618 bytes, a 50% reduction
- The deploy-time optimizer completes in about 0.8 seconds and is idempotent
- Direct TensorFlow.js comparison reports maximum absolute differences of 0.0163 for policy logits and 0.00048 for value output
- 9 browser tests pass
- 2 optimizer tests pass
- Optimized production build passes